### PR TITLE
[#7] Better error messages when the signer cannot read the EC.

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -115,7 +115,7 @@ ospackage {
     packageName='paccor'
     os=LINUX
     arch=NOARCH
-    version='1.0.4'
+    version='1.0.5'
     release='1'
 
     into '/opt/paccor'

--- a/scripts/pc_certgen.sh
+++ b/scripts/pc_certgen.sh
@@ -133,6 +133,10 @@ fi
 # Step 7 create and sign the new platform credential
 echo "Generating a signed Platform Credential"
 bash $signer_bin -x "$extsettings" -c "$componentlist" -e "$ekcert" -p "$policyreference" -k "$sigkey" -P "$pcsigncert" -N "$serialnumber" -b "$dateNotBefore" -a "$dateNotAfter" -f "$pccert" 
+if [ $? -ne 0 ]; then
+    echo "The signer could not produce a Platform Credential, exiting"
+    exit 1
+fi
 
 # Step 8 validate the signature
 echo "Validating the signature"

--- a/src/main/java/cli/DeviceObserverCli.java
+++ b/src/main/java/cli/DeviceObserverCli.java
@@ -63,8 +63,20 @@ public class DeviceObserverCli {
         Holder holder = null;
         InputStreamReader isr = new InputStreamReader(new ByteArrayInputStream(CliHelper.derToPem(ekCertFile, x509type.CERTIFICATE)));
         PEMParser p = new PEMParser(isr);
-        Object readObject = p.readObject();
-        p.close();
+        Object readObject = null;
+        try {
+            readObject = p.readObject();
+        } catch (IOException e) {
+            String msg = "The EK certificate could not be read.";
+            if (e.getMessage().contains("Extra data detected in stream")) {
+                msg += " Check for extra bytes in the given file.";
+            }
+            throw new IOException(msg, e);
+        } finally {
+            if (p != null) {
+                p.close();
+            }
+        }
         if (readObject instanceof X509CertificateHolder) {
             ekCert = (X509CertificateHolder)readObject;
             holder = new Holder(new IssuerSerial(ekCert.getIssuer(), ekCert.getSerialNumber()));


### PR DESCRIPTION
Closes #7.