### PR TITLE
[#27] Recent bug fixes.

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# Platform Credential Creator (paccor)
+# Platform Attribute Certificate Creator (paccor)
 This program can create platform credentials according to the Platform Certificate Profile v1.0. A platform certificate (PC) is a X.509v2 Attribute Certificate which encapsulates details about components on a host and the security standards met by the platform manufacturer.
 
 This program can assist in gathering all of the data that can go into a PC and produce a signed attribute certificate.

--- a/build.gradle
+++ b/build.gradle
@@ -103,7 +103,7 @@ createScript(project, 'cli.DeviceObserverCli', 'observer')
 createScript(project, 'cli.SigningCli', 'signer')
 createScript(project, 'cli.ValidatorCli', 'validator')
 
-// Include files into the ZIP
+// Include files into a ZIP
 applicationDistribution.from("scripts/") {
     into "scripts"
 }
@@ -118,18 +118,21 @@ applicationDistribution.from("./") {
     into "./"
 }
 
+// Produce packages
 ospackage {
     packageName='paccor'
     os=LINUX
     arch=NOARCH
     version='1.0.6'
-    release='2'
+    release='3'
 
     into '/opt/paccor'
     user 'root'
     fileMode=0755
 
+    requires('dmidecode')
     requires('jq')
+    requires('lshw')
 
     from(jar.outputs.files) {
         into 'lib'

--- a/src/main/java/factory/ComponentIdentifierFactory.java
+++ b/src/main/java/factory/ComponentIdentifierFactory.java
@@ -93,7 +93,7 @@ public class ComponentIdentifierFactory {
      * @param serial String
      */
     public final ComponentIdentifierFactory componentSerial(final String serial) {
-        componentSerial = serial != null ? new DERUTF8String(serial) : new DERUTF8String("");
+        componentSerial = serial != null && !serial.trim().isEmpty() ? new DERUTF8String(serial) : null;
         return this;
     }
     
@@ -102,7 +102,7 @@ public class ComponentIdentifierFactory {
      * @param revision String
      */
     public final ComponentIdentifierFactory componentRevision(final String revision) {
-        componentRevision = revision != null ? new DERUTF8String(revision) : new DERUTF8String("");
+        componentRevision = revision != null && !revision.trim().isEmpty() ? new DERUTF8String(revision) : null;
         return this;
     }
     
@@ -111,7 +111,7 @@ public class ComponentIdentifierFactory {
      * @param manufacturerId String
      */
     public final ComponentIdentifierFactory componentManufacturerId(final String manufacturerId) {
-        componentManufacturerId = manufacturerId != null ? new ASN1ObjectIdentifier(manufacturerId) : null;
+        componentManufacturerId = manufacturerId != null && !manufacturerId.trim().isEmpty() ? new ASN1ObjectIdentifier(manufacturerId) : null;
         return this;
     }
     
@@ -121,6 +121,14 @@ public class ComponentIdentifierFactory {
      */
     public final ComponentIdentifierFactory fieldReplaceable(final boolean fieldReplaceable) {
         this.fieldReplaceable = ASN1Boolean.getInstance(fieldReplaceable);
+        return this;
+    }
+    
+    /**
+     * Since it is an optional field, the field replaceable flag could be unset.
+     */
+    public final ComponentIdentifierFactory unsetFieldReplaceable() {
+        this.fieldReplaceable = null;
         return this;
     }
     
@@ -172,8 +180,12 @@ public class ComponentIdentifierFactory {
             // all other fields are optional or have default values
             .componentSerial(serial != null ? serial.asText() : null)
             .componentRevision(revision != null ? revision.asText() : null)
-            .componentManufacturerId(manufacturerId != null ? manufacturerId.asText() : null)
-            .fieldReplaceable(fieldReplaceable != null ? fieldReplaceable.asBoolean() : false);
+            .componentManufacturerId(manufacturerId != null ? manufacturerId.asText() : null);
+            if (fieldReplaceable == null) {
+                component.unsetFieldReplaceable();
+            } else {
+                component.fieldReplaceable(fieldReplaceable != null ? fieldReplaceable.asBoolean() : false);
+            }
             
             JsonNode addresses = refNode.get(ComponentIdentifierFactory.Json.ADDRESSES.name());
             if (addresses != null && addresses.isArray()) {

--- a/src/main/java/tcg/credential/ComponentIdentifier.java
+++ b/src/main/java/tcg/credential/ComponentIdentifier.java
@@ -133,16 +133,16 @@ public class ComponentIdentifier extends ASN1Object {
 			DERUTF8String componentSerial, DERUTF8String componentRevision,
 			ASN1ObjectIdentifier componentManufacturerId, ASN1Boolean fieldReplaceable,
 			ComponentAddress[] componentAddress) {
-		if (componentManufacturer.toString().length() > Definitions.STRMAX) {
+		if (componentManufacturer != null && componentManufacturer.toString().length() > Definitions.STRMAX) {
 			throw new IllegalArgumentException("Length of componentManufacturer exceeds STRMAX");
 		}
-		if (componentModel.toString().length() > Definitions.STRMAX) {
+		if (componentModel != null && componentModel.toString().length() > Definitions.STRMAX) {
 			throw new IllegalArgumentException("Length of componentModel exceeds STRMAX");
 		}
-		if (componentSerial.toString().length() > Definitions.STRMAX) {
+		if (componentSerial != null && componentSerial.toString().length() > Definitions.STRMAX) {
 			throw new IllegalArgumentException("Length of componentSerial exceeds STRMAX");
 		}
-		if (componentRevision.toString().length() > Definitions.STRMAX) {
+		if (componentRevision != null && componentRevision.toString().length() > Definitions.STRMAX) {
 			throw new IllegalArgumentException("Length of componentRevision exceeds STRMAX");
 		}
 		this.componentManufacturer = componentManufacturer;
@@ -152,10 +152,6 @@ public class ComponentIdentifier extends ASN1Object {
 		this.componentManufacturerId = componentManufacturerId;
 		this.fieldReplaceable = fieldReplaceable;
 		this.componentAddress = componentAddress;
-		
-		if (fieldReplaceable == null) {
-		    this.fieldReplaceable = ASN1Boolean.FALSE;
-		}
 	}
 
 	public ASN1Primitive toASN1Primitive() {
@@ -174,7 +170,7 @@ public class ComponentIdentifier extends ASN1Object {
 		if (fieldReplaceable != null) {
 		    vec.add(new DERTaggedObject(false, 3, fieldReplaceable));
 		}
-		if (componentAddress != null) {
+		if (componentAddress != null && componentAddress.length > 0) {
 			ASN1EncodableVector vec2 = new ASN1EncodableVector();
 			for (int i = 0; i < componentAddress.length; i++) {
 				vec2.add(componentAddress[i]);


### PR DESCRIPTION
Closes #26, #27.

* Distros should list lshw and dmidecode as dependencies when trying to install PACCOR.
* Some ComponentIdentifier optional fields were being given empty sequences.  They should be omitted from the final ASN1 structure if there was no data and the field is optional.