### PR TITLE
Gather the EK certificate on Windows

### DIFF
--- a/scripts/windows/get_ek.ps1
+++ b/scripts/windows/get_ek.ps1
@@ -1,0 +1,28 @@
+param(
+    [parameter(Mandatory=$true)]
+    [ValidateNotNull()]
+    [string]$filename
+)
+
+(&{
+        Write-Progress -Activity "Gathering an EK Certificate" -CurrentOperation "Verifying access to the TPM through Windows" -PercentComplete 0
+        If( (New-Object Security.Principal.WindowsPrincipal(
+                [Security.Principal.WindowsIdentity]::GetCurrent())
+            ).IsInRole(
+                [Security.Principal.WindowsBuiltInRole]::Administrator)
+            ) 
+            {
+                Write-Progress -Activity "Gathering an EK Certificate" -CurrentOperation "Accessing the TPM" -PercentComplete 10
+                $data=(Get-TpmEndorsementKeyInfo).ManufacturerCertificates[0].GetRawCertData()
+                Write-Progress -Activity "EK Certificate Gathered" -CurrentOperation "Converting to Base64" -PercentComplete 75
+                $base64 = [Convert]::ToBase64String($data,'InsertLineBreaks')
+                Write-Progress -Activity "EK Certificate Gathered" -CurrentOperation "Writing PEM" -PercentComplete 90
+                $pem = ("-----BEGIN CERTIFICATE-----`n$base64`n-----END CERTIFICATE-----").Replace("`r`n", "`n")
+                [IO.File]::WriteAllText($filename, $pem)
+                Write-Progress "Done" -PercentComplete 100
+            }
+        Else {
+            echo "Not admin"
+        }
+    }
+)


### PR DESCRIPTION
Command line execution from Powershell:
powershell -ExecutionPolicy Bypass .\get_ek.ps1 ek.pem

This script assumes there is an EK certificate on the TPM and it is the first certificate listed when queried.  There may be additional work necessary to search for the EKC through the list of certificates that are available from the TPM.