### PR TITLE
[#47] Created objects to match new certificate fields.

### DIFF
--- a/src/main/java/cli/SigningCli.java
+++ b/src/main/java/cli/SigningCli.java
@@ -6,6 +6,8 @@ import com.beust.jcommander.ParameterException;
 import factory.AuthorityInfoAccessFactory;
 import factory.CertificatePoliciesFactory;
 import factory.PlatformCredentialFactory;
+import factory.TargetingInformationFactory;
+
 import java.io.File;
 import java.io.FileOutputStream;
 import java.io.IOException;
@@ -25,6 +27,7 @@ import org.bouncycastle.asn1.x509.AuthorityInformationAccess;
 import org.bouncycastle.asn1.x509.AuthorityKeyIdentifier;
 import org.bouncycastle.asn1.x509.CRLDistPoint;
 import org.bouncycastle.asn1.x509.Extension;
+import org.bouncycastle.asn1.x509.TargetInformation;
 import org.bouncycastle.asn1.x9.X9ObjectIdentifiers;
 import org.bouncycastle.cert.AttributeCertificateIssuer;
 import org.bouncycastle.cert.X509AttributeCertificateHolder;
@@ -159,6 +162,8 @@ public class SigningCli {
         AuthorityInfoAccessFactory aiaf = OtherExtensionsJsonHelper.accessesFromJsonFile(argList.getExtensionsJsonFile());
         AuthorityInformationAccess aia = aiaf.build();
         CRLDistPoint cdp = OtherExtensionsJsonHelper.crlFromJsonFile(argList.getExtensionsJsonFile());
+        TargetingInformationFactory tif = null; // TargetingInformationFactory.create(); // add ek cert bundle via CLI 
+        TargetInformation ti = tif != null ? tif.build() : null;
         
         pcf.addExtension(Extension.authorityKeyIdentifier, aki);
         pcf.addExtension(Extension.certificatePolicies, cpf.build());
@@ -167,6 +172,9 @@ public class SigningCli {
         }
         if (cdp != null) {
             pcf.addExtension(Extension.cRLDistributionPoints, cdp);
+        }
+        if (ti != null) {
+            pcf.addExtension(Extension.targetInformation, ti);
         }
         
         // Build the cert & sign it using the private key

--- a/src/main/java/factory/PlatformCredentialFactory.java
+++ b/src/main/java/factory/PlatformCredentialFactory.java
@@ -54,6 +54,7 @@ public class PlatformCredentialFactory {
                 put(Extension.authorityInfoAccess, Boolean.FALSE); // Authority Info Access
                 put(Extension.cRLDistributionPoints, Boolean.FALSE); // CRL Distribution
                 put(Extension.subjectAlternativeName, Boolean.FALSE); // Subject Alternative Names
+                put(Extension.targetInformation, Boolean.TRUE); // Targeting Information
             }});
     
     private Holder holder;
@@ -134,6 +135,15 @@ public class PlatformCredentialFactory {
     }
     
     /**
+     * Set the TCG Certificate Specification attribute.
+     */
+    public final PlatformCredentialFactory tcgCertificateSpecification(final TCGSpecificationVersion tcs) {
+        attributes.put(TCGObjectIdentifier.tcgAtTcgCertificateSpecification, tcs);
+        return this;
+    }
+    
+    /**
+     * @deprecated Use tcgCertificateSpecification
      * Set the TCG Credential Specification attribute.
      * @param tcs {@link TCGCredentialSpecification}
      */
@@ -205,16 +215,18 @@ public class PlatformCredentialFactory {
      *   Validity not after (required)
      *   Attributes:
      *    TCG Platform Specification (should)
-     *    TCG Credential Specification (should)
+     *    TCG Certificate Specification (should)
      *    TBB Security Assertions (should)
+     *    TCG Certificate Type (should)
      *    Platform Configuration (may)
      *    Platform Configuration URI (may)
      *   Extensions: 
-     *    Certificate Policies (must) 
-     *    Subject Alternative Names (must)
-     *    Authority Key Identifier (must)
-     *    Authority Info Access (should)
-     *    CRL Distribution (may)
+     *    Certificate Policies (must, non-critical) 
+     *    Subject Alternative Names (must, non-critical)
+     *    Authority Key Identifier (must, non-critical)
+     *    Authority Info Access (should, non-critical)
+     *    CRL Distribution (may, non-critical)
+     *    Targeting Information (may, critical)
      *   Issuer Unique ID (SHOULD NOT)
      *   Signature Algorithm (required)
      *   Signature (required)
@@ -307,7 +319,7 @@ public class PlatformCredentialFactory {
             
             if (root.has(PolicyRefJson.TCGCREDENTIALSPECIFICATION.name())) {
                 JsonNode credentialSpecNode = root.get(PolicyRefJson.TCGCREDENTIALSPECIFICATION.name());
-                pcf.tcgCredentialSpecification(PolicyReferenceJsonHelper.credentialSpec(credentialSpecNode));
+                pcf.tcgCertificateSpecification(PolicyReferenceJsonHelper.credentialSpec(credentialSpecNode));
             }
             
             if (root.has(PolicyRefJson.TBBSECURITYASSERTIONS.name())) {

--- a/src/main/java/factory/TargetingInformationFactory.java
+++ b/src/main/java/factory/TargetingInformationFactory.java
@@ -1,0 +1,93 @@
+package factory;
+
+import java.util.Arrays;
+import java.util.Vector;
+
+import org.bouncycastle.asn1.ASN1ObjectIdentifier;
+import org.bouncycastle.asn1.DERUTF8String;
+import org.bouncycastle.asn1.x500.AttributeTypeAndValue;
+import org.bouncycastle.asn1.x500.RDN;
+import org.bouncycastle.asn1.x500.X500Name;
+import org.bouncycastle.asn1.x500.style.BCStyle;
+import org.bouncycastle.asn1.x509.GeneralName;
+import org.bouncycastle.asn1.x509.Target;
+import org.bouncycastle.asn1.x509.TargetInformation;
+import org.bouncycastle.cert.X509CertificateHolder;
+
+/**
+ * Functions to help manage the creation of the AC targeting extension.
+ */
+public class TargetingInformationFactory {
+    
+private Vector<Target> elements = new Vector<Target>();
+    
+    private TargetingInformationFactory() {
+        elements = new Vector<Target>();
+    }
+    
+    /**
+     * Begin defining the target information extension.
+     */
+    public static final TargetingInformationFactory create() {
+        TargetingInformationFactory tif = new TargetingInformationFactory();
+        return tif;
+    }
+    
+    /**
+     * Add a target element.
+     * @param element {@link Target}
+     */
+    public final TargetingInformationFactory addElement(final Target element) {
+        elements.add(element);
+        return this;
+    }
+    
+    /**
+     * 
+     * @param cert
+     * @return
+     */
+    public final TargetingInformationFactory addCertificate(final X509CertificateHolder cert) {
+        X500Name subjectName = cert.getSubject();
+        
+        if (subjectName == null || cert.getSerialNumber() == null) {
+            throw new IllegalArgumentException("The target information extension cannot use "
+                    + "the provided certificate.  It is missing vital information.");
+        }
+        
+        // The EKC serial number MUST be included as an RDN at oid id-at-serialnumber
+        if (subjectName.getRDNs(BCStyle.SERIALNUMBER).length == 0) {
+            // Add the certificate serial number
+            
+            // Convert the serial number from BigInteger to a RDN
+            DERUTF8String serialNumber = new DERUTF8String(cert.getSerialNumber().toString());
+            AttributeTypeAndValue serialNumberATV = new AttributeTypeAndValue(BCStyle.SERIALNUMBER, serialNumber);
+            RDN serialNumberRdn = new RDN(serialNumberATV);
+            
+            // Add the RDN to the X500Name
+            Vector<RDN> rdns = new Vector<RDN>();
+            rdns.addAll(Arrays.asList(subjectName.getRDNs()));
+            rdns.add(serialNumberRdn);
+            
+            subjectName = new X500Name(rdns.toArray(new RDN[rdns.size()]));
+        }
+        
+        // Add the new Target to the extension
+        Target target = new Target(Target.targetName, new GeneralName(subjectName));
+        addElement(target);
+        return this;
+    }
+    
+    /**
+     * Compile all of the data given to this factory.
+     * @return {@link TargetInformation}
+     */
+    public final TargetInformation build() {
+        if (elements.isEmpty()) {
+            return null;
+        }
+        Target[] targets = elements.toArray(new Target[elements.size()]);
+        TargetInformation ti = new TargetInformation(targets);
+        return ti;
+    }
+}

--- a/src/main/java/tcg/credential/TCGCredentialType.java
+++ b/src/main/java/tcg/credential/TCGCredentialType.java
@@ -1,0 +1,61 @@
+package tcg.credential;
+
+import org.bouncycastle.asn1.ASN1EncodableVector;
+import org.bouncycastle.asn1.ASN1Object;
+import org.bouncycastle.asn1.ASN1ObjectIdentifier;
+import org.bouncycastle.asn1.ASN1Primitive;
+import org.bouncycastle.asn1.ASN1Sequence;
+import org.bouncycastle.asn1.DERSequence;
+
+/**
+ * <pre>
+ * tCGCredentialType ATTRIBUTE ::= {
+ *      WITH SYNTAX TCGCredentialType
+ *      ID tcg-at-tcgCredentialType }
+ * 
+ * TCGCredentialType ::= SEQUENCE {
+ *      certificateType CredentialType }
+ *      
+ * CredentialType ::= OBJECT IDENTIFIER (tcg-kp-PlatformAttributeCertificate | tcg-kp-DeltaPlatformAttributeCertificate)
+ * </pre>
+ */
+public class TCGCredentialType extends ASN1Object {
+    
+    ASN1ObjectIdentifier credentialType;
+    
+    public static TCGCredentialType getInstance(Object obj) {
+        if (obj == null || obj instanceof TCGCredentialType) {
+            return (TCGCredentialType) obj;
+        }
+        if (obj instanceof ASN1Sequence) {
+            return new TCGCredentialType((ASN1Sequence)obj);
+        }
+        throw new IllegalArgumentException("Illegal argument in getInstance: " + obj.getClass().getName());
+    }
+    
+    private TCGCredentialType(ASN1Sequence seq) {
+        if (seq.size() != 1) {
+            throw new IllegalArgumentException("Bad sequence size: " + seq.size());
+        }
+        ASN1Object[] elements = (ASN1Object[]) seq.toArray();
+        if (elements[0] instanceof ASN1ObjectIdentifier) {
+            credentialType = (ASN1ObjectIdentifier) elements[0];
+        } else {
+            throw new IllegalArgumentException("Expected ASN1ObjectIdentifier, received " + elements[0].getClass().getName());
+        }
+    }
+
+    public TCGCredentialType(ASN1ObjectIdentifier credentialType) {
+        this.credentialType = credentialType;
+    }
+
+    public ASN1Primitive toASN1Primitive() {
+        ASN1EncodableVector vec = new ASN1EncodableVector();
+        vec.add(credentialType);
+        return new DERSequence(vec);
+    }
+
+    public ASN1ObjectIdentifier getCredentialType() {
+        return credentialType;
+    }
+}

--- a/src/main/java/tcg/credential/TCGObjectIdentifier.java
+++ b/src/main/java/tcg/credential/TCGObjectIdentifier.java
@@ -29,7 +29,12 @@ public class TCGObjectIdentifier {
 	public static final ASN1ObjectIdentifier tcgAtTcgPlatformSpecification = new ASN1ObjectIdentifier("2.23.133.2.17").intern();
 	public static final ASN1ObjectIdentifier tcgAtTpmSecurityAssertions = new ASN1ObjectIdentifier("2.23.133.2.18").intern();
 	public static final ASN1ObjectIdentifier tcgAtTbbSecurityAssersions = new ASN1ObjectIdentifier("2.23.133.2.19").intern();
+	/**
+	 * @deprecated Use tcgAtTcgCertificateSpecification
+	 */
 	public static final ASN1ObjectIdentifier tcgAtTcgCredentialSpecification = new ASN1ObjectIdentifier("2.23.133.2.23").intern();
+	public static final ASN1ObjectIdentifier tcgAtTcgCertificateSpecification = new ASN1ObjectIdentifier("2.23.133.2.23").intern();
+	public static final ASN1ObjectIdentifier tcgAtTcgCredentialType = new ASN1ObjectIdentifier("2.23.133.2.25").intern();
 	public static final ASN1ObjectIdentifier tcgAtPlatformManufacturerStr = new ASN1ObjectIdentifier("2.23.133.5.1.1").intern();
 	public static final ASN1ObjectIdentifier tcgAtPlatformManufacturerId = new ASN1ObjectIdentifier("2.23.133.5.1.2").intern();
 	public static final ASN1ObjectIdentifier tcgAtPlatformConfigUri = new ASN1ObjectIdentifier("2.23.133.5.1.3").intern();
@@ -38,11 +43,13 @@ public class TCGObjectIdentifier {
 	public static final ASN1ObjectIdentifier tcgAtPlatformSerial = new ASN1ObjectIdentifier("2.23.133.5.1.6").intern();
 	public static final ASN1ObjectIdentifier tcgAtPlatformConfiguration = new ASN1ObjectIdentifier("2.23.133.5.1.7").intern();
 	public static final ASN1ObjectIdentifier tcgAtPlatformConfigurationV1 = new ASN1ObjectIdentifier("2.23.133.5.1.7.1").intern();
+	public static final ASN1ObjectIdentifier tcgAtPlatformConfigurationV2 = new ASN1ObjectIdentifier("2.23.133.5.1.7.2").intern();
 	public static final ASN1ObjectIdentifier tcgAlgorithmNull = new ASN1ObjectIdentifier("2.23.133.4.1").intern();
 	public static final ASN1ObjectIdentifier tcgKpEkCertificate = new ASN1ObjectIdentifier("2.23.133.8.1").intern();
 	public static final ASN1ObjectIdentifier tcgKpPlatformCertificate = new ASN1ObjectIdentifier("2.23.133.8.2").intern();
 	public static final ASN1ObjectIdentifier tcgKpAikCertificate = new ASN1ObjectIdentifier("2.23.133.8.3").intern();
 	public static final ASN1ObjectIdentifier tcgKpPlatformKeyCertificate = new ASN1ObjectIdentifier("2.23.133.8.4").intern();
+	public static final ASN1ObjectIdentifier tcgKpDeltaPlatformAttributeCertificate = new ASN1ObjectIdentifier("2.23.133.8.5").intern();
 	public static final ASN1ObjectIdentifier tcgCeRelevantCredentials = new ASN1ObjectIdentifier("2.23.133.6.2").intern();
 	public static final ASN1ObjectIdentifier tcgCeRelevantManifests = new ASN1ObjectIdentifier("2.23.133.6.3").intern();
 	public static final ASN1ObjectIdentifier tcgCeVirtualPlatformAttestationService = new ASN1ObjectIdentifier("2.23.133.6.4").intern();
@@ -53,4 +60,8 @@ public class TCGObjectIdentifier {
 	public static final ASN1ObjectIdentifier tcgAddressEthernetMac = new ASN1ObjectIdentifier("2.23.133.17.1").intern();
 	public static final ASN1ObjectIdentifier tcgAddressWlanMac = new ASN1ObjectIdentifier("2.23.133.17.2").intern();
 	public static final ASN1ObjectIdentifier tcgAddressBluetoothMac = new ASN1ObjectIdentifier("2.23.133.17.3").intern();
+	public static final ASN1ObjectIdentifier tcgRegistryComponentClass = new ASN1ObjectIdentifier("2.23.133.18.3").intern();
+	public static final ASN1ObjectIdentifier tcgRegistryComponentClassTcg = new ASN1ObjectIdentifier("2.23.133.18.3.1").intern();
+	public static final ASN1ObjectIdentifier tcgRegistryComponentClassIetf = new ASN1ObjectIdentifier("2.23.133.18.3.2").intern();
+	public static final ASN1ObjectIdentifier tcgRegistryComponentClassDmtf = new ASN1ObjectIdentifier("2.23.133.18.3.3").intern();
 }


### PR DESCRIPTION
Closes #47.

Updated TCGObjectIdentifier with new defined attributes.
Created TCGCertificateType.
Created TargetingInformationFactory
Deprecated some references to TCGCredentialSpecification, which is now called TCGCertificateSpecification.
Left alterations to Holder for when I'm implementing delta platform certificates.
