### PR TITLE
[#74] Updated component scripts in attempt to gather OS-agnostic data

### DIFF
--- a/scripts/hw.sh
+++ b/scripts/hw.sh
@@ -1,0 +1,156 @@
+#!/bin/bash
+lshwParse () {
+    type="${1}"
+    str=$(lshw -c "$type" -numeric)
+    numLines=$(printf "$str" | wc -l)
+    items=()
+    busitems=()
+    
+    
+    parsing=""
+    lineItr=0
+    while read -r line; do
+        lineItr=$((lineItr+1))
+        lastLine=""
+        if (($lineItr > $numLines)); then 
+            parsing+="$line"$'\n'
+            lastLine="1"
+        fi
+        if (printf "$line" | grep --quiet -e "^[[:space:]]*\*-.*[[:space:]]*$") || [ -n "$lastLine" ]; then
+            if [ -n "$parsing" ]; then
+                items+=("${parsing}")
+            fi
+            parsing=""
+        fi
+        parsing+="$line"$'\n'
+    done <<< "$str"
+    
+    numItemsDec=$(printf "%d" "0x"${#items[@]})
+    for ((i = 0 ; i < numItemsDec ; i++ )); do
+        matchesType=""
+        if (printf "${items[$i]}" | grep --quiet -e "^\*-"$type"$"); then
+            matchesType="1"
+        fi
+        isPhysical=""
+        if (printf "${items[$i]}" | grep --quiet -e "^bus info:.*$"); then
+            isPhysical="1"
+        fi
+
+        if [ -n "$matchesType" ] && [ -n "$isPhysical" ]; then
+            busitems+=("${items[$i]}")
+        fi        
+    done
+}
+lshwDisk () {
+    lshwParse "disk"
+}
+lshwDisplay () {
+    lshwParse "display"
+}
+lshwNetwork () {
+    lshwParse "network"
+}
+lshwNumBusItems () {
+    printf "${#busitems[@]}"
+}
+lshwGetVendorIDFromBusItem () {
+    itemnumber="${1}"
+    result=""
+    str=$(echo "${busitems[$itemnumber]}" | grep -e "^vendor:.*[^\[]\[.\+$" | sed 's/^vendor:.*[^\[]\[\([0-9A-Fa-f]\{4\}\)\]$/\1/')
+    if [ -n "$str" ]; then
+        result=$str
+    fi
+    printf "$result"
+}
+lshwGetProductIDFromBusItem () {
+    itemnumber="${1}"
+    result=""
+    str=$(echo "${busitems[$itemnumber]}" | grep -e "^product:.*[^\[]\[.\+$" | sed 's/^product:.*[^\[]\[[0-9A-Fa-f]\{4\}:\([0-9A-Fa-f]\{4\}\)\]$/\1/')
+    if [ -n "$str" ]; then
+        result=$str
+    fi
+    printf "$result"
+}
+lshwGetVersionFromBusItem () {
+    itemnumber="${1}"
+    result=""
+    str=$(echo "${busitems[$itemnumber]}" | grep -e "^version:.*$" | sed 's/^version: \([0-9A-Za-z]\+\)$/\1/')
+    if [ -n "$str" ]; then
+        result=$str
+    fi
+    printf "$result"
+}
+lshwGetSerialFromBusItem () {
+    itemnumber="${1}"
+    result=""
+    str=$(echo "${busitems[$itemnumber]}" | grep -e "^serial:.*$" | sed 's/^serial: \([0-9A-Za-Z:-]\+\)$/\1/')
+    if [ -n "$str" ]; then
+        result=$str
+    fi
+    printf "$result"
+}
+lshwGetVendorNameFromBusItem () {
+    itemnumber="${1}"
+    result=""
+    str=$(echo "${busitems[$itemnumber]}" | grep -e "^vendor:.*$" | sed 's/^vendor: \([0-9A-Za-z -]\+\) \?\[\?.*$/\1/')
+    if [ -n "$str" ]; then
+        result=$str
+    fi
+    printf "$result"
+}
+lshwGetProductNameFromBusItem () {
+    itemnumber="${1}"
+    result=""
+    str=$(echo "${busitems[$itemnumber]}" | grep -e "^product:.*$" | sed 's/^product: \([0-9A-Za-z\(\) -]\+\) \?\[\?.*$/\1/')
+    if [ -n "$str" ]; then
+        result=$str
+    fi
+    printf "$result"
+}
+lshwBusItemBluetoothCap () {
+    itemnumber="${1}"
+    result=""
+    if (echo "${busitems[$itemnumber]}" | grep --quiet "capabilities.*bluetooth"); then
+        result="1"
+    fi
+    printf "$result"
+}
+lshwBusItemEthernetCap () {
+    itemnumber="${1}"
+    result=""
+    if (echo "${busitems[$itemnumber]}" | grep --quiet "capabilities.*ethernet"); then
+        result="1"
+    fi
+    printf "$result"
+}
+lshwBusItemWirelessCap () {
+    itemnumber="${1}"
+    result=""
+    if (echo "${busitems[$itemnumber]}" | grep --quiet "capabilities.*wireless"); then
+        result="1"
+    fi
+    printf "$result"
+}
+#lshwParse "disk"
+#lshwNetwork
+#echo ${items[0]}
+#echo ${#busitems[@]}
+#echo ${busitems[*]}
+#ven=$(lshwGetVendorIDFromBusItem "0")
+#prod=$(lshwGetProductIDFromBusItem "0")
+#rev=$(lshwGetVersionFromBusItem "0")
+#serial=$(lshwGetSerialFromBusItem "0")
+#venname=$(lshwGetVendorNameFromBusItem "0")
+#prodname=$(lshwGetProductNameFromBusItem "0")
+#bluetoothCap=$(lshwBusItemBluetoothCap)
+#ethernetCap=$(lshwBusItemEthernetCap)
+#wirelessCap=$(lshwBusItemWirelessCap)
+#echo $ven
+#echo $prod
+#echo $rev
+#echo $serial
+#echo $venname
+#echo $prodname
+#echo $bluetoothCap
+#echo $ethernetCap
+#echo $wirelessCap

--- a/scripts/smbios.sh
+++ b/scripts/smbios.sh
@@ -1,0 +1,77 @@
+#!/bin/bash
+dmidecodeHandles () {
+    type="${1}"
+    str=$(dmidecode -t "$type" | grep -e '^Handle.*' | sed 's/Handle \(0x[0-9A-F^,]*\),.*/\1/' | tr "\n\r\t" ' ' | sed -e 's/^[[:space:]]*//' | sed -e 's/[[:space:]]*$//')
+    old="$IFS"
+    IFS=' '
+    tableHandles=($str)
+    IFS="$old"
+}
+dmidecodeData () {
+    handle="${1}"
+    str=$(dmidecode -H "$handle" -u | awk '/Header and Data:/{f=1;next} /Strings/{f=0} f' | tr "\n\r\t" ' ' | tr -s ' ' | sed -e 's/^[[:space:]]*//' | sed -e 's/[[:space:]]*$//')
+    old="$IFS"
+    IFS=' '
+    tableData=($str)
+    IFS="$old"
+}
+dmidecodeStrings () {
+    handle="${1}"
+    str=$(dmidecode -H "$handle" -u | awk '/Strings/{f=1;next} /^\w+$/{f=0} f' | sed 's/^[^"]*$//g' | sed 's/.*"\(.*\)".*/\1/g' | sed 's/^\w+//g' | sed '/^[[:space:]]*$/d')
+    old="$IFS"
+    IFS=$'\n'
+    tableStrings=($str)
+    IFS="$old"
+}
+dmidecodeParseHandle () {
+    handle="${1}"
+    dmidecodeData "$handle"
+    dmidecodeStrings "$handle"
+}
+dmidecodeNumHandles () {
+    printf "${#tableHandles[@]}"
+}
+dmidecodeParseTypeAssumeOneHandle () {
+    type="${1}"
+    dmidecodeHandles "$type" > /dev/null
+    dmidecodeParseHandle "${tableHandles[0]}"
+}
+dmidecodeGetByte () {
+    index="${1}"
+    index=$(printf "%d" $index)
+    printf "${tableData[$index]}"
+}
+dmidecodeGetString () {
+    strref="${1}"
+    str=""
+    strrefDec=$(printf "%d" "0x""$strref")
+    lenDec=$(printf "%d" "0x"${#tableStrings[@]})
+    if [ $strrefDec -le $lenDec ] && [ $strrefDec -gt 0 ]; then
+        str="${tableStrings[$strrefDec-1]}"
+    fi
+    printf "$str"
+}
+
+
+
+#dmidecodeHandles "4"
+#numHandles=$(dmidecodeNumHandles)
+#echo $numHandles
+#echo ${tableHandles[*]}
+
+#dmidecodeStrings "${tableHandles[0]}"
+
+#echo ${tableStrings[0]}
+
+#dmidecodeData "${tableHandles[0]}"
+
+#manufacturer=${tableData[4]}
+
+#echo "${tableStrings[$manufacturer]}"
+#dmidecodeHandles "2"
+#dmidecodeParseHandle "${tableHandles[0]}"
+#result=$(dmidecodeGetByte "9")
+#result2=$(dmidecodeGetString $result)
+#echo $result2
+#result3=$(dmidecodeGetString $(dmidecodeGetByte "7"))
+#echo $result3

--- a/scripts/windows/SMBios.ps1
+++ b/scripts/windows/SMBios.ps1
@@ -1,0 +1,71 @@
+#
+# This method converts the raw SMBIOS data into an associative array indexed by type.
+# 
+# Usage:  $smbios=(Get-SMBiosStructures)
+#         $smbios[$Type]
+#
+# Adapted from SysToolsLib Powershell Library released under Apache 2.0 License
+# https://github.com/JFLarvoire/SysToolsLib/blob/master/PowerShell/Library.ps1#Get-SMBiosStructures
+# 
+Function Get-SMBiosStructures() {
+  $structs = @{}
+  $data = (Get-WmiObject -Class MSSMBios_RawSMBiosTables -Namespace root\wmi -ErrorAction SilentlyContinue).SMBiosData
+  $i = 0
+  while (($data[$i+1] -ne $null) -and ($data[$i+1] -ne 0)) { # While the structure has non-0 length
+    $i0 = $i
+    $n = $data[$i]   # Structure type
+    $l = $data[$i+1] # Structure length
+    $i += $l # Count bytes from the start of the structure to the beginning of the strings section
+    if ($data[$i] -eq 0) {$i++} # If there's no trailing string, count the extra NUL
+	$strings=@()
+    while ($data[$i] -ne 0) { # Count the size of the string section
+      $s = ""
+      while ($data[$i] -ne 0) { $s += [char]$data[$i++] } # Count the byte length of each string
+	  $strings += $s
+      $i++ # Count the string terminator NUL
+    }
+    $i1 = $i
+	
+	$obj=[pscustomobject]@{
+	    type=$n
+		data=@($data[$i0..$i1])
+		strings=$strings
+	}
+	
+	if ($structs["$n"] -eq $null) {
+	    $structs["$n"] = @()
+	}
+    if ($l -gt 0) {
+        $structs["$n"] += $obj
+    }
+    $i++ # Count the final NUL of the table, and get ready for the next table
+  }
+  return @($structs)
+}
+
+Function Get-SMBiosString($struct, $type, $refbyte) {
+    $str=""
+    if ($struct[$type] -ne $null -and $struct[$type].data -ne $null -and $struct[$type].strings -ne $null) {
+        $strref=$struct[$type].data[$refbyte]
+        $len=@($struct[$type].strings).Count
+        if ($strref -le $len  -and $strref -gt 0) {
+            $str=@($struct[$type].strings)[$struct[$type].data[$refbyte]-1]
+        }
+    }
+    return $str
+}
+
+# Example:
+# $smbios=(Get-SMBiosStructures)
+# echo $smbios["3"]
+# echo $smbios["17"]
+# echo $smbios["3"].strings
+# echo @($smbios["3"].strings)[$smbios["3"].data[4]-1]
+# $platformManufacturer=(Get-SMBiosString $smbios "1" 0x4)
+# $platformModel=(Get-SMBiosString $smbios "1" 0x5)
+# $platformVersion=(Get-SMBiosString $smbios "1" 0x6)
+# $platformSerial=(Get-SMBiosString $smbios "1" 0x7)
+# echo $platformManufacturer
+# echo $platformModel
+# echo $platformVersion
+# echo $platformSerial

--- a/scripts/windows/hw.ps1
+++ b/scripts/windows/hw.ps1
@@ -1,0 +1,55 @@
+function pciParse($str) {
+    $regex="^PCI\\VEN_(?<vendor>[0-9A-Fa-f]{4})&DEV_(?<product>[0-9A-Fa-f]{4})(?:&SUBSYS_(?<subsys1>[A-Za-z0-9]{4})(?<subsys2>[A-Za-z0-9]{4}))?(?:&REV_(?<revision>[A-Za-z0-9]+))?\\.*"
+
+    $parse=$str -match $regex
+    return $matches
+}
+function ideDiskParse($str) {
+    $regex="^IDE\\[Dd][Ii][Ss][Kk]([0-9A-Za-z]+)[_]+(?:([0-9A-Za-z]+)[_]+)?([0-9A-Za-z_]{8})\\.*"
+
+    $parse=$str -match $regex
+    $vendor=""
+    $product=""
+    $revision=""
+    $ptr=0
+    switch ($matches.Count) {
+        4 {$vendor=$matches[$ptr++].Trim("_")}
+        Default {
+            $product=$matches[$ptr++].Trim("_")
+            $revision=$matches[$ptr++].Trim("_")
+        }
+    }
+
+    $obj=[pscustomobject]@{
+        vendor=$vendor
+        product=$product
+        revision=$revision
+    }
+    return $obj
+}
+function scsiDiskParse($str) {
+    $regex="^SCSI\\[Dd][Ii][Ss][Kk](?<vendor>[0-9A-Za-z_-]{8})(?<product>[0-9A-Za-z_-]{16})(?<revision>[0-9A-Za-z_-]{4})\\.*"
+
+    $parse=$str -match $regex
+
+    return $matches
+}
+function isPCI($str) {
+    $regex="^PCI\\.*"
+    return ($str -match $regex)
+}
+function isIDE($str) {
+    $regex="^IDE\\.*"
+    return ($str -match $regex)
+}
+function isSCSI($str) {
+    $regex="^SCSI\\.*"
+    return ($str -match $regex)
+}
+function standardizeMACAddr($str) {
+    $result=$str
+    if (![string]::IsNullOrEmpty($str) -and ($str.Trim().Length -ne 0)) {
+        $result=($str -replace "\s|\\n|\\r|\\t|:|-","").ToUpper()
+    }
+    return $result
+}


### PR DESCRIPTION
Closes #74. 

The component scripts on both Windows and Linux were updated to maximize data pulled directly from SMBIOS tables and hardware IDs rather than accept translated output from the OS.  This should make platform certificates more consistent for a device regardless of what OS it is booted into.