### PR TITLE
[#81] Fix empty string handling from SMBIOS

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -127,13 +127,13 @@ ospackage {
     os=LINUX
     arch=NOARCH
     version='1.1.3'
-    release='2'
+    release='3'
 
     into '/opt/paccor'
     user 'root'
     fileMode=0755
 
-    requires('dmidecode')
+    requires('dmidecode', '3.2', GREATER | EQUAL)
     requires('jq')
     requires('lshw')
     requires('vim-common')

--- a/scripts/allcomponents.sh
+++ b/scripts/allcomponents.sh
@@ -600,13 +600,13 @@ parseNicData () {
         optional="$optional"",""$serial"
     fi
     if ! [[ -z "${revision// }" ]]; then
-        revision=$(echo "$revision" | sed 's/^[ \t]*//;s/[ \t]*$//')
+        revision=$(echo "$revision" | sed 's/^[ \t]*//;s/[ \t]*$//' | awk '{ print toupper($0) }')
         revision=$(jsonRevision "$revision")
         optional="$optional"",""$revision"
     fi
-        bluetoothCap=$(lshwBusItemBluetoothCap)
-        ethernetCap=$(lshwBusItemEthernetCap)
-        wirelessCap=$(lshwBusItemWirelessCap)
+        bluetoothCap=$(lshwBusItemBluetoothCap "$i")
+        ethernetCap=$(lshwBusItemEthernetCap "$i")
+        wirelessCap=$(lshwBusItemWirelessCap "$i")
 
         if ([ -n "$bluetoothCap" ] || [ -n "$ethernetCap" ] || [ -n "$wirelessCap" ]) && ! [[ -z "${serialConstant// }" ]]; then
             thisAddress=
@@ -673,7 +673,7 @@ parseHddData () {
         optional="$optional"",""$serial"
     fi
     if ! [[ -z "${revision// }" ]]; then
-        revision=$(echo "$revision" | sed 's/^[ \t]*//;s/[ \t]*$//')
+        revision=$(echo "$revision" | sed 's/^[ \t]*//;s/[ \t]*$//' | awk '{ print toupper($0) }')
         revision=$(jsonRevision "$revision")
         optional="$optional"",""$revision"
     fi
@@ -727,7 +727,7 @@ parseGfxData () {
         optional="$optional"",""$serial"
     fi
     if ! [[ -z "${revision// }" ]]; then
-        revision=$(echo "$revision" | sed 's/^[ \t]*//;s/[ \t]*$//')
+        revision=$(echo "$revision" | sed 's/^[ \t]*//;s/[ \t]*$//' | awk '{ print toupper($0) }')
         revision=$(jsonRevision "$revision")
         optional="$optional"",""$revision"
     fi

--- a/scripts/hw.sh
+++ b/scripts/hw.sh
@@ -83,7 +83,7 @@ lshwGetVersionFromBusItem () {
 lshwGetSerialFromBusItem () {
     itemnumber="${1}"
     result=""
-    str=$(echo "${busitems[$itemnumber]}" | grep -e "^serial:.*$" | sed 's/^serial: \([0-9A-Za-Z:-]\+\)$/\1/')
+    str=$(echo "${busitems[$itemnumber]}" | grep -e "^serial:.*$" | sed 's/^serial: \([0-9A-Za-z:-]\+\)$/\1/')
     if [ -n "$str" ]; then
         result=$str
     fi

--- a/scripts/smbios.sh
+++ b/scripts/smbios.sh
@@ -17,7 +17,7 @@ dmidecodeData () {
 }
 dmidecodeStrings () {
     handle="${1}"
-    str=$(dmidecode -H "$handle" -u | awk '/Strings/{f=1;next} /^\w+$/{f=0} f' | sed 's/^[^"]*$//g' | sed 's/.*"\(.*\)".*/\1/g' | sed 's/^\w+//g' | sed '/^[[:space:]]*$/d')
+    str=$(dmidecode -H "$handle" -u | awk '/Strings/{f=1;next} /^\w+$/{f=0} f' | sed 's/^[^"]*$//g' | sed 's/^\w+//g' | sed '/^[[:space:]]*$/d')
     old="$IFS"
     IFS=$'\n'
     tableStrings=($str)
@@ -48,13 +48,14 @@ dmidecodeGetString () {
     lenDec=$(printf "%d" "0x"${#tableStrings[@]})
     if [ $strrefDec -le $lenDec ] && [ $strrefDec -gt 0 ]; then
         str="${tableStrings[$strrefDec-1]}"
+        str=$(printf "$str" | sed 's/^[ \t]*"\?//;s/"\?[ \t]*$//')
     fi
     printf "$str"
 }
 
 
-
-#dmidecodeHandles "4"
+# Examples:
+#dmidecodeHandles "1"
 #numHandles=$(dmidecodeNumHandles)
 #echo $numHandles
 #echo ${tableHandles[*]}
@@ -65,13 +66,13 @@ dmidecodeGetString () {
 
 #dmidecodeData "${tableHandles[0]}"
 
-#manufacturer=${tableData[4]}
-
-#echo "${tableStrings[$manufacturer]}"
-#dmidecodeHandles "2"
-#dmidecodeParseHandle "${tableHandles[0]}"
-#result=$(dmidecodeGetByte "9")
-#result2=$(dmidecodeGetString $result)
-#echo $result2
-#result3=$(dmidecodeGetString $(dmidecodeGetByte "7"))
-#echo $result3
+#manufacturer=$(dmidecodeGetString $(dmidecodeGetByte "0x4"))
+#model=$(dmidecodeGetByte "0x6")
+#model=$(printf "%d" "0x""$model") # Convert to decimal
+#model=$(dmidecodeGetString $(dmidecodeGetByte "0x5"))
+#serial=$(dmidecodeGetString $(dmidecodeGetByte "0x7"))
+#revision=$(dmidecodeGetString $(dmidecodeGetByte "0x6"))
+#echo $manufacturer
+#echo $model
+#echo $serial
+#echo $revision


### PR DESCRIPTION
Closes #81.

Fixed the issue with reading SMBIOS strings in smbios.sh.  Also fixed typos in hw.sh.
Increased the version number of paccor to 1.1.3r3