### PR TITLE
[#86] NVMe support in component gathering script on linux

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -126,8 +126,8 @@ ospackage {
     packageName='paccor'
     os=LINUX
     arch=NOARCH
-    version='1.1.3'
-    release='4'
+    version='1.1.4'
+    release='1'
 
     into '/opt/paccor'
     user 'root'
@@ -137,6 +137,7 @@ ospackage {
     requires('ethtool')
     requires('jq')
     requires('lshw')
+    requires('nvme-cli')
     requires('vim-common')
 
     from(jar.outputs.files) {

--- a/scripts/allcomponents.sh
+++ b/scripts/allcomponents.sh
@@ -10,6 +10,7 @@ ENTERPRISE_NUMBERS_FILE="$APP_HOME""/enterprise-numbers"
 PEN_ROOT="1.3.6.1.4.1." # OID root for the private enterprise numbers
 SMBIOS_SCRIPT="$APP_HOME""/smbios.sh"
 HW_SCRIPT="$APP_HOME""/hw.sh" # For components not covered by SMBIOS
+NVME_SCRIPT="$APP_HOME""/nvme.sh" # For nvme components, until lshw supports them
 
 ### SMBIOS Type Constants
 source $SMBIOS_SCRIPT
@@ -22,6 +23,7 @@ SMBIOS_TYPE_RAM="17"
 
 ### hw
 source $HW_SCRIPT
+source $NVME_SCRIPT
 
 ### ComponentClass values
 COMPCLASS_REGISTRY_TCG="2.23.133.18.3.1" # switch off values within SMBIOS to reveal accurate component classes
@@ -690,6 +692,50 @@ parseHddData () {
     printf "$tmpData"
 }
 
+parseNvmeData () {
+    nvmeParse
+
+    replaceable=$(jsonFieldReplaceable "true")
+    tmpData=""
+    numHandles=$(nvmeNumDevices)
+    class=$(jsonComponentClass "$COMPCLASS_REGISTRY_TCG" "$COMPCLASS_HDD")
+
+    for ((i = 0 ; i < numHandles ; i++ )); do
+        manufacturer="" # Making this appear as it does on windows, lshw doesn't see nvme drives and nvme-cli doesn't return a manufacturer field
+        model=$(nvmeGetModelNumberForDevice "$i")
+        serial=$(nvmeGetNguidForDevice "$i")
+        revision="" # empty for a similar reason to the manufacturer field
+
+    if [[ -z "${manufacturer// }" ]]; then
+        manufacturer="$NOT_SPECIFIED"
+    fi
+    manufacturer=$(echo "$manufacturer" | sed 's/^[ \t]*//;s/[ \t]*$//')
+    manufacturer=$(jsonManufacturer "$manufacturer")
+
+    if [[ -z "${model// }" ]]; then
+        model="$NOT_SPECIFIED"
+    fi
+    model=$(echo "${model:0:16}" | sed 's/^[ \t]*//;s/[ \t]*$//') # limited to 16 characters for compatibility to windows, then trimmed
+    model=$(jsonModel "$model")
+
+    optional=""
+    if ! [[ -z "${serial// }" ]]; then
+        serial=$(echo "${serial^^}" | sed 's/^[ \t]*//;s/[ \t]*$//' | sed 's/.\{4\}/&_/g' | sed 's/_$/\./')
+        serial=$(jsonSerial "$serial")
+        optional="$optional"",""$serial"
+    fi
+    optional=$(printf "$optional" | cut -c2-)
+
+        newHddData=$(jsonComponent "$class" "$manufacturer" "$model" "$replaceable" "$optional")
+        tmpData="$tmpData"",""$newHddData"
+    done
+
+    # remove leading comma
+    tmpData=$(printf "$tmpData" | cut -c2-)
+
+    printf "$tmpData"
+}
+
 parseGfxData () {
     lshwDisplay
 
@@ -754,8 +800,9 @@ componentsCPU=$(parseCpuData)
 componentsRAM=$(parseRamData)
 componentsNIC=$(parseNicData)
 componentsHDD=$(parseHddData)
+componentsNVMe=$(parseNvmeData)
 componentsGFX=$(parseGfxData)
-componentArray=$(jsonComponentArray "$componentChassis" "$componentBaseboard" "$componentBios" "$componentsCPU" "$componentsRAM" "$componentsNIC" "$componentsHDD" "$componentsGFX")
+componentArray=$(jsonComponentArray "$componentChassis" "$componentBaseboard" "$componentBios" "$componentsCPU" "$componentsRAM" "$componentsNIC" "$componentsHDD" "$componentsNVMe" "$componentsGFX")
 
 ### Collate the property details
 propertyArray=$(jsonPropertyArray "$property1" "$property2")

--- a/scripts/hw.sh
+++ b/scripts/hw.sh
@@ -142,9 +142,8 @@ lshwBusItemWirelessCap () {
 }
 ethtoolPermAddr () {
     iface="${1}"
-    result=""
     str=$(ethtool -P "$iface" 2> /dev/null | grep -e "^Perm.*$" | sed 's/^Permanent address: \([0-9a-f:]\+\)$/\1/')
-    printf "$result"
+    printf "$str"
 }
 #lshwParse "disk"
 #lshwNetwork

--- a/scripts/nvme.sh
+++ b/scripts/nvme.sh
@@ -1,0 +1,37 @@
+#!/bin/bash
+# Gather descriptors for NVMe devices  
+nvmeParse () {
+    str=$(nvme list -o json)
+    count=$(echo "$str" | jq '.Devices | length')
+    nvmedevices=()
+
+    for ((i = 0 ; i < count ; i++ )); do
+        elementJson=$(echo "$str" | jq .Devices["$i"])
+        nvmedevices+=("$elementJson")        
+    done
+}
+nvmeNumDevices () {
+    printf "${#nvmedevices[@]}"
+}
+nvmeGetModelNumberForDevice () {
+    dev="${1}"
+    str=$(echo "${nvmedevices[$dev]}" | jq -r .ModelNumber)
+    printf "$str"
+}
+nvmeGetSerialNumberForDevice () {
+    dev="${1}"
+    str=$(echo "${nvmedevices[$dev]}" | jq -r .SerialNumber)
+    printf "$str"
+}
+nvmeGetEuiForDevice () {
+    dev="${1}"
+    devNode=$(echo "${nvmedevices[$dev]}" | jq -r .DevicePath)
+    str=$(nvme id-ns "$devNode" -o json | jq -r .eui64)
+    printf "$str"
+}
+nvmeGetNguidForDevice () {
+    dev="${1}"
+    devNode=$(echo "${nvmedevices[$dev]}" | jq -r .DevicePath)
+    str=$(nvme id-ns "$devNode" -o json | jq -r .nguid)
+    printf "$str"
+}


### PR DESCRIPTION
Closes #86.

lshw doesn't collect info about NVMe drives.  This PR adds support to collect that information and format it similar to how those drives are seen on windows.  The problems with how a NVMe drive is represented on Windows need to be investigated separately.