### PR TITLE
[#88] Handle case of empty NVMe nguid

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -127,7 +127,7 @@ ospackage {
     os=LINUX
     arch=NOARCH
     version='1.1.4'
-    release='1'
+    release='2'
 
     into '/opt/paccor'
     user 'root'

--- a/scripts/allcomponents.sh
+++ b/scripts/allcomponents.sh
@@ -704,6 +704,9 @@ parseNvmeData () {
         manufacturer="" # Making this appear as it does on windows, lshw doesn't see nvme drives and nvme-cli doesn't return a manufacturer field
         model=$(nvmeGetModelNumberForDevice "$i")
         serial=$(nvmeGetNguidForDevice "$i")
+        if [[ $serial =~ ^[0]+$ ]]; then
+            serial=$(nvmeGetEuiForDevice "$i")
+        fi
         revision="" # empty for a similar reason to the manufacturer field
 
     if [[ -z "${manufacturer// }" ]]; then


### PR DESCRIPTION
Closes #88 

In the case that the nguid is empty, the eui64 field also contains identifying information that can be used for comparison.  