### PR TITLE
[#95] Fixed parsing of change to lshw report of network components

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -117,7 +117,7 @@ ospackage {
     os=LINUX
     arch=NOARCH
     version='1.1.4'
-    release='3'
+    release='4'
 
     into '/opt/paccor'
     user 'root'

--- a/scripts/hw.sh
+++ b/scripts/hw.sh
@@ -28,7 +28,7 @@ lshwParse () {
     numItemsDec=$(printf "%d" "0x"${#items[@]})
     for ((i = 0 ; i < numItemsDec ; i++ )); do
         matchesType=""
-        if (printf "${items[$i]}" | grep --quiet -e "^\*-"$type"[[:space:]]*\(DISABLED\)\?$"); then
+        if (printf "${items[$i]}" | grep --quiet -e "^\*-"$type"\?[0-9A-Fa-f]*[[:space:]]*\(DISABLED\)\?$"); then
             matchesType="1"
         fi
         isPhysical=""


### PR DESCRIPTION
Closes #95.

Encountered a situation where physical network components can have extra characters in their lshw output. Those extra characters broke paccor's parser which caused the components to not be included in paccor's output.