### PR TITLE
adding PROPERTYSTATUS option to allcomponents.ps1

### DIFF
--- a/scripts/allcomponents.sh
+++ b/scripts/allcomponents.sh
@@ -76,6 +76,7 @@ JSON_HASHVALUE="HASHVALUE"
 #### JSON Properties Keywords
 JSON_NAME="NAME"
 JSON_VALUE="VALUE"
+JSON_PROP_STATUS="STATUS"
 NOT_SPECIFIED="Not Specified"
 
 
@@ -109,6 +110,13 @@ JSON_PROPERTY_TEMPLATE='
         {
             \"'"$JSON_NAME"'\": \"%s\",
             \"'"$JSON_VALUE"'\": \"%s\"
+        }
+'
+JSON_PROPERTY_TEMPLATE_OPT='
+        {
+            \"'"$JSON_NAME"'\": \"%s\",
+            \"'"$JSON_VALUE"'\": \"%s\",
+            \"'"$JSON_PROP_STATUS"'\": \"%s\"
         }
 '
 JSON_ADDRESSES_TEMPLATE=' \"'"$JSON_ADDRESSES"'\": [%s]'
@@ -208,7 +216,7 @@ queryForPen () {
 jsonProperty () {
     if [ -n "${1}" ] && [ -n "${2}" ]; then
         if [ -n "${3}" ]; then
-            printf "$JSON_PROPERTY_TEMPLATE" "${1}" "${2}" "${3}"
+            printf "$JSON_PROPERTY_TEMPLATE_OPT" "${1}" "${2}" "${3}"
         else
             printf "$JSON_PROPERTY_TEMPLATE" "${1}" "${2}"
         fi
@@ -796,7 +804,7 @@ parseGfxData () {
 
 ### Gather property details
 property1=$(jsonProperty "uname -r" "$(uname -r)")  ## Example1
-property2=$(jsonProperty "OS Release" "$(grep 'PRETTY_NAME=' /etc/os-release | sed 's/[^=]*=//' | sed -e 's/^[[:space:]\"]*//' | sed -e 's/[[:space:]\"]*$//')") ## Example2
+property2=$(jsonProperty "OS Release" "$(grep 'PRETTY_NAME=' /etc/os-release | sed 's/[^=]*=//' | sed -e 's/^[[:space:]\"]*//' | sed -e 's/[[:space:]\"]*$//')" "samplestatus") ## Example2
 
 ### Collate the component details
 componentsCPU=$(parseCpuData)

--- a/scripts/windows/allcomponents.ps1
+++ b/scripts/windows/allcomponents.ps1
@@ -85,6 +85,7 @@ $JSON_HASHVALUE="HASHVALUE"
 #### JSON Properties Keywords
 $JSON_NAME="NAME"
 $JSON_VALUE="VALUE"
+$JSON_PROP_STATUS="STATUS"
 $NOT_SPECIFIED="Not Specified"
 
 
@@ -120,6 +121,13 @@ $JSON_PROPERTY_TEMPLATE="
             `"$JSON_VALUE`": `"{1}`"
         }}
 "
+$JSON_PROPERTY_TEMPLATE_OPT="
+        {{
+            `"$JSON_NAME`": `"{0}`",
+            `"$JSON_VALUE`": `"{1}`",
+            `"$JSON_PROP_STATUS`": `"{2}`"
+        }}
+"
 $JSON_ADDRESSES_TEMPLATE=" `"$JSON_ADDRESSES`": [{0}]"
 $JSON_ETHERNETMAC_TEMPLATE=" {{
                 `"$JSON_ETHERNETMAC`": `"{0}`" }} "
@@ -149,7 +157,6 @@ $JSON_COMPONENTPLATFORMCERTURI_TEMPLATE='
     }}'
 $JSON_STATUS_TEMPLATE="
     `"$JSON_STATUS`": {{
-
     }}"
 
 ### JSON Constructor Aides
@@ -242,6 +249,8 @@ function queryForPen () {
 function jsonProperty () {
     if ($args.Length -eq 2) {
         echo ("$JSON_PROPERTY_TEMPLATE" -f "$($args[0])","$($args[1])")
+    } elseif ($args.Length -eq 3) {
+        echo ("$JSON_PROPERTY_TEMPLATE_OPT" -f "$($args[0])","$($args[1])","$($args[2])")
     }
 }
 function jsonUri () {
@@ -853,10 +862,10 @@ $componentArray=(jsonComponentArray "$componentChassis" "$componentBaseboard" "$
 Write-Progress -Id 1 -Activity "Gathering properties" -PercentComplete 80
 $osCaption=((wmic os get caption /value | Select-String -Pattern "^.*=(.*)$").Matches.Groups[1].ToString().Trim())
 $property1=(jsonProperty "caption" "$osCaption")  ## Example1
-$property2= ## Example2
+$property2=(jsonProperty "caption" "$osCaption" "samplestatus") ## Example2 (including optional status field)
 
 ### Collate the property details
-$propertyArray=(jsonPropertyArray "$property1")
+$propertyArray=(jsonPropertyArray "$property1" "$property2")
 
 ### Collate the URI details, if parameters above are blank, the fields will be excluded from the final JSON structure
 $componentsUri=""
@@ -874,4 +883,3 @@ $FINAL_JSON_OBJECT=(jsonIntermediateFile "$platform" "$componentArray" "$compone
 
 Write-Progress -Id 1 -Activity "Done" -PercentComplete 100
 [IO.File]::WriteAllText($filename, "$FINAL_JSON_OBJECT")
-


### PR DESCRIPTION
According to the V2 documentation the Property JSON object can have the following attributes: 
`
@param name String property name
`
`
@param value String property value
`
`
@param status AttributeStatus property status
`

PlatformConfigurationV2Factory.java considers the optional **PROPERTYSTATUS** attribute in line 202:

`final JsonNode statusNode = property.has(Json.PROPERTYSTATUS.name()) ? property.get(Json.PROPERTYSTATUS.name()) : null;`


However, the corresponding Powershell script **"allcomponents.ps1"** which generates **"localhost-componentlist.json"** 
does not offer the option to specify a **PROPERTYSTATUS**.

I have modified **"allcomponents.ps1"** so that the user can add a PROPERTYSTATUS.

I will also adjust the .sh script accordingly if the Powershell script change is accepted.
