### PR TITLE
Changed arch option in build.gradle

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -115,9 +115,8 @@ applicationDistribution.from("./") {
 ospackage {
     packageName='paccor'
     os=LINUX
-    arch=all
     version='1.1.4'
-    release='6'
+    release='7'
 
     into '/opt/paccor'
     user 'root'


### PR DESCRIPTION
Closes #106. 

Removing the arch option seems to fix this. The plugin will specify noarch or all automatically based on distro.