### PR TITLE
Collection scripts to use the Component Class Registries

### DIFF
--- a/.github/docker/Dockerfile.paccor-builder
+++ b/.github/docker/Dockerfile.paccor-builder
@@ -1,0 +1,82 @@
+FROM rockylinux:9
+LABEL org.opencontainers.image.vendor="NSA Laboratory for Advanced Cybersecurity Research"
+LABEL org.opencontainers.image.source="https://github.com/nsacyber/paccor"
+LABEL org.opencontainers.image.description="Tools for build, test, and deployment of paccor and HIRS projects."
+
+# REF can be specified as a docker run environment variable to select the HIRS branch to work with
+ENV REF=main
+# BUILD, is an environment variable that if not empty, will attempt to run gradle bootWar on the cloned branch
+ENV BUILD=
+# PREF can be specified as a docker run environment variable to select the paccor branch to work with
+ENV PREF=main
+
+SHELL ["/bin/bash", "-c"]
+
+# Rocky 9 has a different channel for some apps
+RUN dnf install -y 'dnf-command(config-manager)' && dnf config-manager --set-enabled crb
+
+# Update and install OS-dependencies
+RUN dnf update -y
+# Dependencies were selected for these reasons:
+#   OS setup/Unknown direct impact for HIRS
+ENV HIRS_DNF_OS_SETUP="initscripts firewalld policycoreutils policycoreutils-python-utils net-tools" 
+#   OS tools
+ENV HIRS_DNF_OS_TOOLS="git sudo vim wget"
+#   ACA compile
+ENV HIRS_DNF_ACA_COMPILE="java-17-openjdk-devel"
+#   ACA run
+ENV HIRS_DNF_ACA_RUN="mariadb-server"
+#   IBM TPM simulator compile
+ENV HIRS_DNF_TPM_COMPILE="tpm2-tools gcc cmake openssl-devel"
+#   IBM TSS compile
+ENV HIRS_DNF_TSS_COMPILE="autoconf automake libtool"
+#   .NET SDK
+ENV HIRS_DNF_DOTNET_SDK="dotnet-sdk-8.0"
+#   Paccor
+ENV HIRS_DNF_PACCOR=""
+# Download and install all dependencies at one time
+RUN dnf -y install $(echo "$HIRS_DNF_OS_SETUP") $(echo "$HIRS_DNF_OS_TOOLS") $(echo "$HIRS_DNF_ACA_COMPILE") $(echo "$HIRS_DNF_ACA_RUN") $(echo "$HIRS_DNF_TPM_COMPILE") $(echo "$HIRS_DNF_TSS_COMPILE") $(echo "$HIRS_DNF_DOTNET_SDK") $(echo "$HIRS_DNF_PACCOR")
+
+# Install dotnet tools
+RUN dotnet tool install --global dotnet-deb
+RUN dotnet tool install --global dotnet-rpm
+RUN dotnet tool install --global dotnet-zip
+# Add dotnet PATHs
+ENV PATH="/root/.dotnet:/root/.dotnet/tools:$PATH"
+
+# Build IBM TPM Simulator
+RUN git clone https://github.com/kgoldman/ibmswtpm2 /ibmswtpm2
+WORKDIR /ibmswtpm2/src
+RUN make
+
+# Build IBM TPM tools
+RUN git clone https://github.com/kgoldman/ibmtss /ibmtss
+WORKDIR /ibmtss/utils
+RUN make -f makefiletpmc
+
+# The following script tests that the SW TPM and TSS were compiled in the docker image. And documents how to start the SW TPM after container launch using both IBM's tss and TPM2-TOOLS.
+RUN echo "#!/bin/bash" > /tmp/tpm_config && \
+    echo "/ibmswtpm2/src/tpm_server &" >> /tmp/tpm_config && \
+    echo "sleep 5" >> /tmp/tpm_config && \
+    echo "/ibmtss/utils/startup -c" >> /tmp/tpm_config && \
+    echo "tpm2_shutdown" >> /tmp/tpm_config && \
+    echo "tpm2_startup -c" >> /tmp/tpm_config && \
+    echo "/ibmtss/utils/shutdown -c" >> /tmp/tpm_config && \
+    bash /tmp/tpm_config && \
+    rm -rf /tmp/tpm_config
+
+# Checkout paccor
+RUN git clone -b main https://github.com/nsacyber/paccor.git /paccor
+
+# Checkout HIRS
+RUN git clone -b main https://github.com/nsacyber/HIRS.git /hirs
+
+COPY ./checkout_build.sh /tmp/
+RUN chmod 755 /tmp/checkout_build.sh
+RUN /tmp/checkout_build.sh ${REF} ${PREF} y
+
+# Reset working directory
+WORKDIR /paccor
+
+# On container launch, checkout and build as requested then leave at the command prompt.
+CMD ["bash", "-c", "/tmp/checkout_build.sh ${REF} ${PREF} ${BUILD} && /bin/bash"]

--- a/.github/docker/checkout_build.sh
+++ b/.github/docker/checkout_build.sh
@@ -1,0 +1,111 @@
+#!/bin/bash
+
+REF=$1
+PREF=$2
+BUILD=$3
+
+if [[ -z "${REF// }" ]]; then
+    REF="main"
+fi
+if [[ -z "${PREF// }" ]]; then
+    PREF="main"
+fi
+
+# Check out HIRS branch
+cd /hirs
+git fetch origin && git pull origin main && git reset --hard
+git checkout $REF && git reset --hard
+
+# Check out paccor branch
+cd /paccor
+git fetch origin && git pull origin main && git reset --hard
+git checkout $PREF && git reset --hard
+
+if [[ -z "${BUILD// }" ]]; then
+    exit
+fi
+
+rm -rf /hirs/**/build
+rm -rf /paccor/build
+
+cd /hirs
+./gradlew clean bootWar
+
+cd /paccor
+./gradlew clean build 
+
+# Build Provisioner
+cd /hirs/HIRS_Provisioner.NET
+dotnet restore
+/hirs/HIRS_Provisioner.NET/hirs
+dotnet test
+dotnet deb install
+dotnet rpm install
+dotnet zip install
+dotnet deb -r linux-x64 -c Debug
+dotnet rpm -r linux-x64 -c Debug
+dotnet zip -r linux-x64 -c Debug
+dotnet deb -r linux-x64 -c Release
+dotnet rpm -r linux-x64 -c Release
+dotnet zip -r linux-x64 -c Release
+
+# Build HardwareManifestPlugin
+cd /paccor/dotnet/HardwareManifestPlugin
+dotnet restore
+cd /paccor/dotnet/HardwareManifestPlugin/HardwareManifestPlugin
+dotnet build -r linux-x64 -c Debug
+dotnet build -r linux-x64 -c Release
+cd /paccor/dotnet/HardwareManifestPlugin/HardwareManifestPluginManager
+dotnet build -r linux-x64 -c Debug
+dotnet build -r linux-x64 -c Release
+
+# Build paccor_scripts
+cd /paccor/dotnet/paccor_scripts
+dotnet restore
+cd /paccor/dotnet/paccor_scripts/paccor_scripts
+dotnet build -r linux-x64 -c Release
+
+# Build Component Class registries
+cd /paccor/dotnet/ComponentClassRegistry
+dotnet restore
+cd /paccor/dotnet/ComponentClassRegistry/PcieCli
+dotnet deb install
+dotnet rpm install
+dotnet zip install
+dotnet deb -r linux-x64 -c Debug
+dotnet rpm -r linux-x64 -c Debug
+dotnet zip -r linux-x64 -c Debug
+dotnet zip -r win-x64 -c Debug
+dotnet deb -r linux-x64 -c Release
+dotnet rpm -r linux-x64 -c Release
+dotnet zip -r linux-x64 -c Release
+dotnet zip -r win-x64 -c Release
+cd /paccor/dotnet/ComponentClassRegistry/SmbiosCli
+dotnet deb install
+dotnet rpm install
+dotnet zip install
+dotnet deb -r linux-x64 -c Debug
+dotnet rpm -r linux-x64 -c Debug
+dotnet zip -r linux-x64 -c Debug
+dotnet zip -r win-x64 -c Debug
+dotnet deb -r linux-x64 -c Release
+dotnet rpm -r linux-x64 -c Release
+dotnet zip -r linux-x64 -c Release
+dotnet zip -r win-x64 -c Release
+cd /paccor/dotnet/ComponentClassRegistry/StorageCli
+dotnet deb install
+dotnet rpm install
+dotnet zip install
+dotnet deb -r linux-x64 -c Debug
+dotnet rpm -r linux-x64 -c Debug
+dotnet zip -r linux-x64 -c Debug
+dotnet zip -r win-x64 -c Debug
+dotnet deb -r linux-x64 -c Release
+dotnet rpm -r linux-x64 -c Release
+dotnet zip -r linux-x64 -c Release
+dotnet zip -r win-x64 -c Release
+
+cd /paccor
+./gradlew buildDeb buildRpm distZipLinux distZipWin
+
+

--- a/.github/workflows/build-dist.yml
+++ b/.github/workflows/build-dist.yml
@@ -18,6 +18,8 @@ jobs:
       - name: Install Package Tools
         working-directory: dotnet/ComponentClassRegistry
         run: |
+          dotnet tool install --global dotnet-deb
+          dotnet tool install --global dotnet-rpm
           dotnet tool install --global dotnet-zip
       - name: SMBIOS Cli
         working-directory: dotnet/ComponentClassRegistry/SmbiosCli

--- a/.github/workflows/build-dist.yml
+++ b/.github/workflows/build-dist.yml
@@ -22,19 +22,31 @@ jobs:
       - name: SMBIOS Cli
         working-directory: dotnet/ComponentClassRegistry/SmbiosCli
         run: |
+          dotnet deb install
+          dotnet rpm install
           dotnet zip install
+          dotnet deb -r linux-x64 -c Release
+          dotnet rpm -r linux-x64 -c Release
           dotnet zip -r linux-x64 -c Release
           dotnet zip -r win-x64 -c Release
       - name: PCIe Cli
         working-directory: dotnet/ComponentClassRegistry/PcieCli
         run: |
+          dotnet deb install
+          dotnet rpm install
           dotnet zip install
+          dotnet deb -r linux-x64 -c Release
+          dotnet rpm -r linux-x64 -c Release
           dotnet zip -r linux-x64 -c Release
           dotnet zip -r win-x64 -c Release
       - name: Storage Cli
         working-directory: dotnet/ComponentClassRegistry/StorageCli
         run: |
+          dotnet deb install
+          dotnet rpm install
           dotnet zip install
+          dotnet deb -r linux-x64 -c Release
+          dotnet rpm -r linux-x64 -c Release
           dotnet zip -r linux-x64 -c Release
           dotnet zip -r win-x64 -c Release
       - name: Build packages
@@ -44,6 +56,9 @@ jobs:
         shell: bash
         run: |
           sha256sum build/distributions/*.{deb,rpm,zip} 2> /dev/null
+          ls -go --full-time build/distributions/*.{deb,rpm,zip} 2> /dev/null
+          sha256sum dotnet/ComponentClassRegistry/{PcieCli,SmbiosCli,StorageCli}/bin/**/**/**/*.{deb,rpm,zip} 2> /dev/null
+          ls -go --full-time dotnet/ComponentClassRegistry/{PcieCli,SmbiosCli,StorageCli}/bin/**/**/**/*.{deb,rpm,zip} 2> /dev/null
       - name: Artifacts
         uses: actions/upload-artifact@v4
         with:
@@ -54,3 +69,12 @@ jobs:
             build/distributions/*.deb
             build/distributions/*.rpm
             build/distributions/*.zip
+            dotnet/ComponentClassRegistry/SmbiosCli/**/*.deb
+            dotnet/ComponentClassRegistry/SmbiosCli/**/*.rpm
+            dotnet/ComponentClassRegistry/SmbiosCli/**/*.zip
+            dotnet/ComponentClassRegistry/PcieCli/**/*.deb
+            dotnet/ComponentClassRegistry/PcieCli/**/*.rpm
+            dotnet/ComponentClassRegistry/PcieCli/**/*.zip
+            dotnet/ComponentClassRegistry/StorageCli/**/*.deb
+            dotnet/ComponentClassRegistry/StorageCli/**/*.rpm
+            dotnet/ComponentClassRegistry/StorageCli/**/*.zip

--- a/.github/workflows/build-dist.yml
+++ b/.github/workflows/build-dist.yml
@@ -1,0 +1,56 @@
+name: Build Distribution Packages
+
+on:
+  push:
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - name: Setup .NET
+        uses: actions/setup-dotnet@v4
+        with:
+          dotnet-version: 8.0.x
+      - name: Restore dependencies
+        working-directory: dotnet/ComponentClassRegistry
+        run: dotnet restore
+      - name: Install Package Tools
+        working-directory: dotnet/ComponentClassRegistry
+        run: |
+          dotnet tool install --global dotnet-zip
+      - name: SMBIOS Cli
+        working-directory: dotnet/ComponentClassRegistry/SmbiosCli
+        run: |
+          dotnet zip install
+          dotnet zip -r linux-x64 -c Release
+          dotnet zip -r win-x64 -c Release
+      - name: PCIe Cli
+        working-directory: dotnet/ComponentClassRegistry/PcieCli
+        run: |
+          dotnet zip install
+          dotnet zip -r linux-x64 -c Release
+          dotnet zip -r win-x64 -c Release
+      - name: Storage Cli
+        working-directory: dotnet/ComponentClassRegistry/StorageCli
+        run: |
+          dotnet zip install
+          dotnet zip -r linux-x64 -c Release
+          dotnet zip -r win-x64 -c Release
+      - name: Build packages
+        run: |
+          ./gradlew clean build buildRpm buildDeb distZipWin distZipLinux
+      - name: Artifacts SHA256
+        shell: bash
+        run: |
+          sha256sum build/distributions/*.{deb,rpm,zip} 2> /dev/null
+      - name: Artifacts
+        uses: actions/upload-artifact@v4
+        with:
+          name: dists
+          retention-days: 1
+          if-no-files-found: error
+          path: |
+            build/distributions/*.deb
+            build/distributions/*.rpm
+            build/distributions/*.zip

--- a/.github/workflows/dotnet-build-componentclassregistry.yml
+++ b/.github/workflows/dotnet-build-componentclassregistry.yml
@@ -72,26 +72,27 @@ jobs:
         dotnet rpm -r linux-x64 -c Release
         dotnet zip -r linux-x64 -c Release
         dotnet zip -r win-x64 -c Release
-    - name: Artifacts SHA256
+    - name: Debug Apps SHA256
       shell: bash
       run: |
-        sha256sum dotnet/ComponentClassRegistry/{PcieCli,SmbiosCli,StorageCli}/bin/**/**/**/*.{deb,rpm,zip} 2> /dev/null
+        sha256sum dotnet/ComponentClassRegistry/{PcieCli,SmbiosCli,StorageCli}/bin/Debug/**/**/*.{deb,rpm,zip} 2> /dev/null
+        ls -go --full-time dotnet/ComponentClassRegistry/{PcieCli,SmbiosCli,StorageCli}/bin/Debug/**/**/*.{deb,rpm,zip} 2> /dev/null
     - name: Artifacts
       uses: actions/upload-artifact@v4
       with:
-        name: testArtifacts.${{ matrix.os }}
+        name: debugapps.builton_${{ matrix.os }}
         retention-days: 1
         if-no-files-found: error
         path: |
-          dotnet/ComponentClassRegistry/SmbiosCli/**/*.deb
-          dotnet/ComponentClassRegistry/SmbiosCli/**/*.rpm
-          dotnet/ComponentClassRegistry/SmbiosCli/**/*.zip
-          dotnet/ComponentClassRegistry/PcieCli/**/*.deb
-          dotnet/ComponentClassRegistry/PcieCli/**/*.rpm
-          dotnet/ComponentClassRegistry/PcieCli/**/*.zip
-          dotnet/ComponentClassRegistry/StorageCli/**/*.deb
-          dotnet/ComponentClassRegistry/StorageCli/**/*.rpm
-          dotnet/ComponentClassRegistry/StorageCli/**/*.zip
+          dotnet/ComponentClassRegistry/SmbiosCli/bin/Debug/**/*.deb
+          dotnet/ComponentClassRegistry/SmbiosCli/bin/Debug/**/*.rpm
+          dotnet/ComponentClassRegistry/SmbiosCli/bin/Debug/**/*.zip
+          dotnet/ComponentClassRegistry/PcieCli/bin/Debug/**/*.deb
+          dotnet/ComponentClassRegistry/PcieCli/bin/Debug/**/*.rpm
+          dotnet/ComponentClassRegistry/PcieCli/bin/Debug/**/*.zip
+          dotnet/ComponentClassRegistry/StorageCli/bin/Debug/**/*.deb
+          dotnet/ComponentClassRegistry/StorageCli/bin/Debug/**/*.rpm
+          dotnet/ComponentClassRegistry/StorageCli/bin/Debug/**/*.zip
   nuget:
     runs-on: ubuntu-latest
     needs: build
@@ -111,10 +112,11 @@ jobs:
         shell: bash
         run: |
           sha256sum dotnet/ComponentClassRegistry/**/bin/Release/*nupkg
+          ls -go --full-time dotnet/ComponentClassRegistry/**/bin/Release/*nupkg
       - name: Nuget Packages
         uses: actions/upload-artifact@v4
         with:
-          name: nuget.pkgs
+          name: nuget.rc.pkgs
           retention-days: 1
           if-no-files-found: error
           path: |

--- a/.github/workflows/dotnet-build-hardwaremanifest.yml
+++ b/.github/workflows/dotnet-build-hardwaremanifest.yml
@@ -27,3 +27,16 @@ jobs:
     - name: Pack
       working-directory: dotnet/HardwareManifestPlugin
       run: dotnet pack
+    - name: Nuget SHA256
+      shell: bash
+      run: |
+        sha256sum dotnet/HardwareManifestPlugin/**/bin/Release/*nupkg
+        ls -go --full-time dotnet/HardwareManifestPlugin/**/bin/Release/*nupkg
+    - name: Nuget Packages
+      uses: actions/upload-artifact@v4
+      with:
+        name: nuget.pkgs
+        retention-days: 1
+        if-no-files-found: error
+        path: |
+          dotnet/HardwareManifestPlugin/**/bin/Release/*nupkg

--- a/.github/workflows/dotnet-build-hardwaremanifest.yml
+++ b/.github/workflows/dotnet-build-hardwaremanifest.yml
@@ -35,7 +35,7 @@ jobs:
     - name: Nuget Packages
       uses: actions/upload-artifact@v4
       with:
-        name: nuget.pkgs
+        name: nuget.rc.builton_${{ matrix.os }}
         retention-days: 1
         if-no-files-found: error
         path: |

--- a/.github/workflows/dotnet-build-paccor_scripts.yml
+++ b/.github/workflows/dotnet-build-paccor_scripts.yml
@@ -40,7 +40,7 @@ jobs:
     - name: Nuget Packages
       uses: actions/upload-artifact@v4
       with:
-        name: nuget.pkgs
+        name: nuget.rc.builton_${{ matrix.os }}
         retention-days: 1
         if-no-files-found: error
         path: |

--- a/.github/workflows/dotnet-build-paccor_scripts.yml
+++ b/.github/workflows/dotnet-build-paccor_scripts.yml
@@ -32,3 +32,16 @@ jobs:
       run: |
         dotnet publish -r linux-x64 -c Release
         dotnet publish -r win-x64 -c Release
+    - name: Nuget SHA256
+      shell: bash
+      run: |
+        sha256sum dotnet/paccor_scripts/paccor_scripts/bin/Release/*nupkg
+        ls -go --full-time dotnet/paccor_scripts/paccor_scripts/bin/Release/*nupkg
+    - name: Nuget Packages
+      uses: actions/upload-artifact@v4
+      with:
+        name: nuget.pkgs
+        retention-days: 1
+        if-no-files-found: error
+        path: |
+          dotnet/paccor_scripts/paccor_scripts/bin/Release/*nupkg

--- a/.github/workflows/gradle-wrapper-validation.yml
+++ b/.github/workflows/gradle-wrapper-validation.yml
@@ -6,5 +6,5 @@ jobs:
     name: "Gradle Wrapper Validation"
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v2
-      - uses: gradle/wrapper-validation-action@v1.0.3
+      - uses: actions/checkout@v4
+      - uses: gradle/actions/wrapper-validation@v3

--- a/build.gradle
+++ b/build.gradle
@@ -117,6 +117,12 @@ def createScript(project, mainClass, name) {
       duplicatesStrategy = 'exclude' // IMPORTANT: eliminates duplicate files within the ZIP
     }
   }
+    tasks.named("buildDeb") {
+        dependsOn tasks.named(name)
+    }
+    tasks.named("buildRpm") {
+        dependsOn tasks.named(name)
+    }
 }
 
 // Suppress standard application plugin behavior in favor of easier to read program declarations below
@@ -140,6 +146,129 @@ applicationDistribution.from("./") {
         details.file.name.endsWith('.md')
     }
     into "./"
+}
+
+def createCcrPathString(String ccr, String config, String runtime) {
+    def prefix = "${project.rootDir}${File.separator}dotnet${File.separator}ComponentClassRegistry"
+    def netVersion = "net8.0"
+    return "${prefix}${File.separator}${ccr}${File.separator}bin${File.separator}${config}${File.separator}${netVersion}${File.separator}${runtime}${File.separator}publish${File.separator}${ccr}"
+}
+
+def getDotnetConfig() {
+    return "Release"
+}
+
+def getDotnetRuntimeLinux() {
+    return "linux-x64"
+}
+
+def getDotnetRuntimeWin() {
+    return "win-x64"
+}
+
+def getZipOutputPath() {
+    return layout.buildDirectory.dir("distributions")
+}
+
+def getStagingPathForUtilities() {
+    return layout.buildDirectory.dir("tmp${File.separator}staging")
+}
+
+def createLinuxZipFileList() {
+    def config = getDotnetConfig()
+    def runtime = getDotnetRuntimeLinux()
+    def smbios = file(createCcrPathString("SmbiosCli", config, runtime))
+    def pcie = file(createCcrPathString("PcieCli", config, runtime))
+    def storage = file(createCcrPathString("StorageCli", config, runtime))
+
+    return [smbios, pcie, storage]
+}
+
+def createWinZipFileList() {
+    def config = getDotnetConfig()
+    def runtime = getDotnetRuntimeWin()
+    def smbios = file(createCcrPathString("SmbiosCli", config, runtime) + ".exe")
+    def pcie = file(createCcrPathString("PcieCli", config, runtime) + ".exe")
+    def storage = file(createCcrPathString("StorageCli", config, runtime) + ".exe")
+
+    return [smbios, pcie, storage]
+}
+
+def checkFilesExist(ArrayList<File> fileList, String destinationIfExists) {
+    fileList.each { file ->
+        if (file.exists()) {
+            println "Copied ${file.name} into ${destinationIfExists}."
+        }
+    }
+}
+
+// Create Windows ZIP
+tasks.register("distZipWin", Zip) {
+    dependsOn tasks.named("distZip")
+
+    def destinationInZip = tasks.distZip.archiveBaseName.get() + "${File.separator}scripts${File.separator}windows"
+    def zipOutputDestination = getZipOutputPath()
+    def runtime = getDotnetRuntimeWin()
+    def archiveName = tasks.distZip.archiveBaseName.get() + "_${runtime}.zip"
+
+    def fileList = createWinZipFileList()
+
+    from(zipTree(tasks.distZip.archiveFile.get().asFile))
+    from(fileList.findAll { it.exists() }) {
+        into "${destinationInZip}"
+    }
+
+    archiveFileName.set(archiveName)
+    destinationDirectory.set(zipOutputDestination)
+
+    doFirst {
+        checkFilesExist(fileList, "${archiveName}")
+    }
+}
+
+// Create Linux ZIP
+tasks.register("distZipLinux", Zip) {
+    dependsOn tasks.named("distZip")
+
+    def destinationInZip = tasks.distZip.archiveBaseName.get() + "${File.separator}scripts"
+    def zipOutputDestination = getZipOutputPath()
+    def runtime = getDotnetRuntimeLinux()
+    def archiveName = tasks.distZip.archiveBaseName.get() + "_${runtime}.zip"
+
+    def fileList = createLinuxZipFileList()
+
+    from(zipTree(tasks.distZip.archiveFile.get().asFile))
+    from(fileList.findAll { it.exists() }) {
+        into "${destinationInZip}"
+    }
+
+    archiveFileName.set(archiveName)
+    destinationDirectory.set(zipOutputDestination)
+
+    doFirst {
+        checkFilesExist(fileList, "${archiveName}")
+    }
+}
+
+// Copies linux registry utilities into a packaging staging folder, if they exist
+tasks.register("stageRegistryUtilitiesForPackaging", Copy) {
+    def stagingFolder = file(getStagingPathForUtilities())
+    def fileList = createLinuxZipFileList()
+
+    from fileList.findAll { it.exists() }
+    into "${stagingFolder}"
+
+    doFirst {
+        checkFilesExist(fileList, "${stagingFolder}")
+    }
+}
+
+tasks.named("buildDeb") {
+    dependsOn tasks.named("stageRegistryUtilitiesForPackaging")
+}
+
+tasks.named("buildRpm") {
+    dependsOn tasks.named("stageRegistryUtilitiesForPackaging")
 }
 
 // Produce packages
@@ -198,6 +327,10 @@ ospackage {
             details.file.name.endsWith('.md')
         }
         into './'
+    }
+
+    from (getStagingPathForUtilities()) {
+        into 'scripts'
     }
 }
 

--- a/dotnet/paccor_scripts/paccor_scripts/paccor_scripts.csproj
+++ b/dotnet/paccor_scripts/paccor_scripts/paccor_scripts.csproj
@@ -7,7 +7,7 @@
     <RuntimeIdentifiers>linux-x64;win-x64</RuntimeIdentifiers>
     <Authors>NSA Cybersecurity Directorate</Authors>
     <PackageId>paccor.paccor_scripts</PackageId>
-    <PackageVersion>2.0.5</PackageVersion>
+    <PackageVersion>2.1.0</PackageVersion>
     <PackageTags>paccor;platform;certificate;hardware;manifest;scripts;component;class;registry;evidence;collection</PackageTags>
     <PackageReadmeFile>README.md</PackageReadmeFile>
     <PackageLicenseExpression>Apache-2.0</PackageLicenseExpression>

--- a/dotnet/paccor_scripts/paccor_scripts/paccor_scripts.csproj
+++ b/dotnet/paccor_scripts/paccor_scripts/paccor_scripts.csproj
@@ -21,8 +21,8 @@
 
   <Target Name="CopyFiles" BeforeTargets="PreBuildEvent">
     <ItemGroup>
-      <PaccorScriptsLinux Include="..\..\..\scripts\allcomponents.sh;..\..\..\scripts\enterprise-numbers;..\..\..\scripts\hw.sh;..\..\..\scripts\nvme.sh;..\..\..\scripts\smbios.sh" />
-	  <PaccorScriptsWindows Include="..\..\..\scripts\windows\allcomponents.ps1;..\..\..\scripts\windows\hw.ps1;..\..\..\scripts\windows\nvme.ps1;..\..\..\scripts\windows\SMBios.ps1" />
+      <PaccorScriptsLinux Include="..\..\..\scripts\allcomponents.sh;..\..\..\scripts\enterprise-numbers;..\..\..\scripts\hw.sh;..\..\..\scripts\json.sh;..\..\..\scripts\nvme.sh;..\..\..\scripts\smbios.sh..\..\..\scripts\tcg_ccr.sh" />
+	  <PaccorScriptsWindows Include="..\..\..\scripts\windows\allcomponents.ps1;..\..\..\scripts\windows\hw.ps1;..\..\..\scripts\windows\json.ps1;..\..\..\scripts\windows\nvme.ps1;..\..\..\scripts\windows\SMBios.ps1;..\..\..\scripts\windows\tcg_ccr.ps1" />
     </ItemGroup>
     <Copy SourceFiles="@(PaccorScriptsLinux)" DestinationFolder="$(ProjectDir)scripts" />
 	<Copy SourceFiles="@(PaccorScriptsWindows)" DestinationFolder="$(ProjectDir)scripts/windows" />

--- a/dotnet/paccor_scripts/paccor_scripts/sbom_buildlist_file.txt
+++ b/dotnet/paccor_scripts/paccor_scripts/sbom_buildlist_file.txt
@@ -2,9 +2,13 @@ paccor_scripts.dll
 scripts/allcomponents.sh
 scripts/enterprise-numbers
 scripts/hw.sh
+scripts/json.sh
 scripts/nvme.sh
 scripts/smbios.sh
+scripts/tcg_ccr.sh
 scripts/windows/allcomponents.ps1
 scripts/windows/hw.ps1
+scripts/windows/json.ps1
 scripts/windows/nvme.ps1
 scripts/windows/SMBios.ps1
+scripts/windows/tcg_ccr.ps1

--- a/dotnet/paccor_scripts/paccor_scripts/src/PaccorComponentScriptsPlugin.cs
+++ b/dotnet/paccor_scripts/paccor_scripts/src/PaccorComponentScriptsPlugin.cs
@@ -5,10 +5,10 @@ using System.Runtime.InteropServices;
 namespace paccor_scripts {
     public sealed class PaccorComponentScriptsPlugin : HardwareManifestPluginBase {
         public static readonly string Scripts = Path.GetFullPath(Path.Combine(Path.GetDirectoryName(typeof(PaccorComponentScriptsPlugin).Assembly.Location)!, "scripts"));
-        public static readonly string LinuxComponents = Path.GetFullPath(Path.Combine(Scripts, "allcomponents.sh"));
+        public static readonly string LinuxComponents = Path.GetFullPath(Path.Combine(Scripts, "tcg_ccr.sh"));
         public static readonly string WinPath = Path.GetFullPath(Path.Combine(Scripts, "windows"));
         public static readonly string WinTempOutput = Path.GetFullPath(Path.Combine(WinPath, "out.json"));
-        public static readonly string WinComponents = Path.GetFullPath(Path.Combine(WinPath, "allcomponents.ps1"));
+        public static readonly string WinComponents = Path.GetFullPath(Path.Combine(WinPath, "tcg_ccr.ps1"));
 
         public static readonly string TraitDescription = "paccor component gathering scripts";
         public static readonly string TraitDescriptionUri = "https://github.com/nsacyber/paccor/scripts";

--- a/dotnet/paccor_scripts/paccor_scripts/src/ShellHelper.cs
+++ b/dotnet/paccor_scripts/paccor_scripts/src/ShellHelper.cs
@@ -6,7 +6,7 @@ namespace paccor_scripts {
             var escapedArgs = cmd.Replace("\"", "\\\"");
             ProcessStartInfo info = new() {
                 FileName = "bash",
-                Arguments = $"\"{escapedArgs}\"",
+                Arguments = $"\"{escapedArgs}\" /dev/stdout",
                 RedirectStandardOutput = true,
                 RedirectStandardError = true,
                 UseShellExecute = false,

--- a/scripts/allcomponents.sh
+++ b/scripts/allcomponents.sh
@@ -23,6 +23,12 @@ PCIE_REGISTRY_UTILITY="$APP_HOME""/PcieCli"
 STORAGE_REGISTRY_UTILITY="$APP_HOME""/StorageCli"
 TCG_REGISTRY_SCRIPT="$APP_HOME""/tcg_ccr.sh"
 
+## Some of the commands below require root.
+if [ "$EUID" -ne 0 ]
+  then echo "Please run as root"
+  exit
+fi
+
 ### SMBIOS Type Constants
 source $SMBIOS_SCRIPT
 SMBIOS_TYPE_SYSTEM="1"
@@ -30,12 +36,6 @@ SMBIOS_TYPE_PLATFORM="$SMBIOS_TYPE_SYSTEM"
 
 ### JSON
 source $JSON_SCRIPT
-
-## Some of the commands below require root.
-if [ "$EUID" -ne 0 ]
-  then echo "Please run as root"
-  exit
-fi
 
 ### Gather platform details for the subject alternative name
 parseSystemData () {

--- a/scripts/allcomponents.sh
+++ b/scripts/allcomponents.sh
@@ -1,27 +1,23 @@
 #!/bin/bash
 
 ### User customizable values
-APP_HOME="`dirname "$0"`"
+APP_HOME=$(dirname "$0")
 COMPONENTS_URI="" # Specify the optional components URI field
+# shellcheck disable=SC2034
 COMPONENTS_URI_LOCAL_COPY_FOR_HASH="" # If empty, the optional hashAlgorithm and hashValue fields will not be included for the URI
 PROPERTIES_URI="" # Specify the optional properties URI field
+# shellcheck disable=SC2034
 PROPERTIES_URI_LOCAL_COPY_FOR_HASH="" # If empty, the optional hashAlgorithm and hashValue fields will not be included for the URI
-ENTERPRISE_NUMBERS_FILE="$APP_HOME""/enterprise-numbers"
-PEN_ROOT="1.3.6.1.4.1." # OID root for the private enterprise numbers
 JSON_SCRIPT="$APP_HOME""/json.sh" # Defines JSON structure and provides methods for producing relevant JSON
-SMBIOS_SCRIPT="$APP_HOME""/smbios.sh"
-HW_SCRIPT="$APP_HOME""/hw.sh" # For some components not covered by SMBIOS
-NVME_SCRIPT="$APP_HOME""/nvme.sh" # For nvme components
 
 #### Registry Options
-INCLUDE_SMBIOS_REGISTRY="1"
-INCLUDE_PCIE_REGISTRY="1"
-INCLUDE_STORAGE_REGISTRY="1"
-INCLUDE_TCG_REGISTRY=""
+INCLUDE_SMBIOS_REGISTRY=YES
+INCLUDE_PCIE_REGISTRY=YES
+INCLUDE_STORAGE_REGISTRY=YES
+INCLUDE_TCG_REGISTRY=
 SMBIOS_REGISTRY_UTILITY="$APP_HOME""/SmbiosCli"
 PCIE_REGISTRY_UTILITY="$APP_HOME""/PcieCli"
 STORAGE_REGISTRY_UTILITY="$APP_HOME""/StorageCli"
-TCG_REGISTRY_SCRIPT="$APP_HOME""/tcg_ccr.sh"
 
 ## Some of the commands below require root.
 if [ "$EUID" -ne 0 ]
@@ -29,67 +25,33 @@ if [ "$EUID" -ne 0 ]
   exit
 fi
 
-### SMBIOS Type Constants
-source $SMBIOS_SCRIPT
-SMBIOS_TYPE_SYSTEM="1"
-SMBIOS_TYPE_PLATFORM="$SMBIOS_TYPE_SYSTEM"
-
 ### JSON
-source $JSON_SCRIPT
+# shellcheck source=./json.sh
+source "$JSON_SCRIPT"
 
-### Gather platform details for the subject alternative name
-parseSystemData () {
-    dmidecodeParseTypeAssumeOneHandle "$SMBIOS_TYPE_PLATFORM"
-    platformManufacturer=$(dmidecodeGetString $(dmidecodeGetByte "0x4"))
-    platformModel=$(dmidecodeGetString $(dmidecodeGetByte "0x5"))
-    platformVersion=$(dmidecodeGetString $(dmidecodeGetByte "0x6"))
-    platformSerial=$(dmidecodeGetString $(dmidecodeGetByte "0x7"))
-
-    if [[ -z "${platformManufacturer// }" ]]; then
-        platformManufacturer="$NOT_SPECIFIED"
-    fi
-    platformManufacturer=$(echo "$platformManufacturer" | sed 's/^[ \t]*//;s/[ \t]*$//')
-    platformManufacturer=$(jsonPlatformManufacturerStr "$platformManufacturer")
-
-    if [[ -z "${platformModel// }" ]]; then
-        platformModel="$NOT_SPECIFIED"
-    fi
-    platformModel=$(echo "$platformModel" | sed 's/^[ \t]*//;s/[ \t]*$//')
-    platformModel=$(jsonPlatformModel "$platformModel")
-
-    if [[ -z "${platformVersion// }" ]]; then
-        platformVersion="$NOT_SPECIFIED"
-    fi
-    platformVersion=$(echo "$platformVersion" | sed 's/^[ \t]*//;s/[ \t]*$//')
-    platformVersion=$(jsonPlatformVersion "$platformVersion")
-
-    if ! [[ -z "${platformSerial// }" ]]; then
-        platformSerial=$(echo "$platformSerial" | sed 's/^[ \t]*//;s/[ \t]*$//')
-        platformSerial=$(jsonPlatformSerial "$platformSerial")
-    fi
-    platform=$(jsonPlatformObject "$platformManufacturer" "$platformModel" "$platformVersion" "$platformSerial")
-
-    printf "$platform"
-}
+### Base Registry Platform and Component data
+TCG_REGISTRY_SCRIPT="$APP_HOME""/tcg_ccr.sh" # Functions to collect hardware information labeled with the original TCG Component Class Registry
+# shellcheck source=./tcg_ccr.sh
+source "$TCG_REGISTRY_SCRIPT"
 
 ### Gather component details
-platform=$(parseSystemData)
+platformList=$(parseSystemData)
+platformObject=$(jsonPlatformObject "$platformList")
 smbiosRegistryData=""
 pcieRegistryData=""
 storageRegistryData=""
 tcgRegistryData=""
-if ! [[ -z "${INCLUDE_SMBIOS_REGISTRY// }" ]]; then
+if [[ -n "$INCLUDE_SMBIOS_REGISTRY" && -f "$SMBIOS_REGISTRY_UTILITY" ]]; then
     smbiosRegistryData=$($SMBIOS_REGISTRY_UTILITY --components-only)
 fi
-if ! [[ -z "${INCLUDE_PCIE_REGISTRY// }" ]]; then
+if [[ -n "$INCLUDE_PCIE_REGISTRY" && -f "$PCIE_REGISTRY_UTILITY" ]]; then
     pcieRegistryData=$($PCIE_REGISTRY_UTILITY --components-only)
 fi
-if ! [[ -z "${INCLUDE_STORAGE_REGISTRY// }" ]]; then
+if [[ -n "$INCLUDE_STORAGE_REGISTRY" && -f "$STORAGE_REGISTRY_UTILITY" ]]; then
     storageRegistryData=$($STORAGE_REGISTRY_UTILITY --components-only)
 fi
-if ! [[ -z "${INCLUDE_TCG_REGISTRY// }" ]]; then
-    source $TCG_REGISTRY_SCRIPT
-    tcgRegistryData=$(collectBasicRegistryComponents)
+if [[ -n "$INCLUDE_TCG_REGISTRY" ]]; then
+    tcgRegistryData=$(collectOldTcgRegistryComponents)
 fi
 componentArray=$(jsonComponentArray "$smbiosRegistryData" "$pcieRegistryData" "$storageRegistryData" "$tcgRegistryData")
 
@@ -100,19 +62,19 @@ property2=$(jsonProperty "OS Release" "$(grep 'PRETTY_NAME=' /etc/os-release | s
 ### Collate the property details
 propertyArray=$(jsonPropertyArray "$property1" "$property2")
 
-### Construct the final JSON object
-FINAL_JSON_OBJECT=$(jsonIntermediateFile "$platform" "$componentArray" "$propertyArray")
-
 ### Collate the URI details, if parameters above are blank, the fields will be excluded from the final JSON structure
+componentsUri=""
 if [ -n "$COMPONENTS_URI" ]; then
-    componentsUri=$(jsonComponentsUri)
-    FINAL_JSON_OBJECT="$FINAL_JSON_OBJECT"",""$componentsUri"
+    componentsUri=$(jsonComponentsUri "$COMPONENTS_URI" "$COMPONENTS_URI_LOCAL_COPY_FOR_HASH")
 fi
+propertiesUri=""
 if [ -n "$PROPERTIES_URI" ]; then
-    propertiesUri=$(jsonPropertiesUri)
-    FINAL_JSON_OBJECT="$FINAL_JSON_OBJECT"",""$propertiesUri"
+    propertiesUri=$(jsonPropertiesUri "$PROPERTIES_URI" "$PROPERTIES_URI_LOCAL_COPY_FOR_HASH")
 fi
 
-printf "$FINAL_JSON_OBJECT""\n\n"
+### Construct the final JSON object
+FINAL_JSON_OBJECT=$(jsonIntermediateFile "$platformObject" "$componentArray" "$componentsUri" "$propertyArray" "$propertiesUri")
+
+printf "%s\n\n" "$FINAL_JSON_OBJECT"
 
 

--- a/scripts/allcomponents.sh
+++ b/scripts/allcomponents.sh
@@ -10,33 +10,23 @@ ENTERPRISE_NUMBERS_FILE="$APP_HOME""/enterprise-numbers"
 PEN_ROOT="1.3.6.1.4.1." # OID root for the private enterprise numbers
 JSON_SCRIPT="$APP_HOME""/json.sh" # Defines JSON structure and provides methods for producing relevant JSON
 SMBIOS_SCRIPT="$APP_HOME""/smbios.sh"
-HW_SCRIPT="$APP_HOME""/hw.sh" # For components not covered by SMBIOS
-NVME_SCRIPT="$APP_HOME""/nvme.sh" # For nvme components, until lshw supports them
+HW_SCRIPT="$APP_HOME""/hw.sh" # For some components not covered by SMBIOS
+NVME_SCRIPT="$APP_HOME""/nvme.sh" # For nvme components
+
+#### Registry Options
+INCLUDE_SMBIOS_REGISTRY="1"
+INCLUDE_PCIE_REGISTRY="1"
+INCLUDE_STORAGE_REGISTRY="1"
+INCLUDE_TCG_REGISTRY=""
+SMBIOS_REGISTRY_UTILITY="$APP_HOME""/SmbiosCli"
+PCIE_REGISTRY_UTILITY="$APP_HOME""/PcieCli"
+STORAGE_REGISTRY_UTILITY="$APP_HOME""/StorageCli"
+TCG_REGISTRY_SCRIPT="$APP_HOME""/tcg_ccr.sh"
 
 ### SMBIOS Type Constants
 source $SMBIOS_SCRIPT
-SMBIOS_TYPE_PLATFORM="1"
-SMBIOS_TYPE_CHASSIS="3"
-SMBIOS_TYPE_BIOS="0"
-SMBIOS_TYPE_BASEBOARD="2"
-SMBIOS_TYPE_CPU="4"
-SMBIOS_TYPE_RAM="17"
-
-### hw
-source $HW_SCRIPT
-source $NVME_SCRIPT
-
-### ComponentClass values
-COMPCLASS_REGISTRY_TCG="2.23.133.18.3.1" # switch off values within SMBIOS to reveal accurate component classes
-COMPCLASS_BASEBOARD="00030003" # these values are meant to be an example.  check the component class registry.
-COMPCLASS_BIOS="00130003"
-COMPCLASS_UEFI="00130002"
-COMPCLASS_CHASSIS="00020001" # TODO:  chassis type is included in SMBIOS
-COMPCLASS_CPU="00010002"
-COMPCLASS_HDD="00070002"
-COMPCLASS_NIC="00090002"
-COMPCLASS_RAM="00060001"  # TODO: memory type is included in SMBIOS
-COMPCLASS_GFX="00050002"
+SMBIOS_TYPE_SYSTEM="1"
+SMBIOS_TYPE_PLATFORM="$SMBIOS_TYPE_SYSTEM"
 
 ### JSON
 source $JSON_SCRIPT
@@ -48,520 +38,64 @@ if [ "$EUID" -ne 0 ]
 fi
 
 ### Gather platform details for the subject alternative name
-dmidecodeParseTypeAssumeOneHandle "$SMBIOS_TYPE_PLATFORM"
-platformManufacturer=$(dmidecodeGetString $(dmidecodeGetByte "0x4"))
-platformModel=$(dmidecodeGetString $(dmidecodeGetByte "0x5"))
-platformVersion=$(dmidecodeGetString $(dmidecodeGetByte "0x6"))
-platformSerial=$(dmidecodeGetString $(dmidecodeGetByte "0x7"))
+parseSystemData () {
+    dmidecodeParseTypeAssumeOneHandle "$SMBIOS_TYPE_PLATFORM"
+    platformManufacturer=$(dmidecodeGetString $(dmidecodeGetByte "0x4"))
+    platformModel=$(dmidecodeGetString $(dmidecodeGetByte "0x5"))
+    platformVersion=$(dmidecodeGetString $(dmidecodeGetByte "0x6"))
+    platformSerial=$(dmidecodeGetString $(dmidecodeGetByte "0x7"))
 
-if [[ -z "${platformManufacturer// }" ]]; then
-    platformManufacturer="$NOT_SPECIFIED"
-fi
-platformManufacturer=$(echo "$platformManufacturer" | sed 's/^[ \t]*//;s/[ \t]*$//')
-platformManufacturer=$(jsonPlatformManufacturerStr "$platformManufacturer")
+    if [[ -z "${platformManufacturer// }" ]]; then
+        platformManufacturer="$NOT_SPECIFIED"
+    fi
+    platformManufacturer=$(echo "$platformManufacturer" | sed 's/^[ \t]*//;s/[ \t]*$//')
+    platformManufacturer=$(jsonPlatformManufacturerStr "$platformManufacturer")
 
-if [[ -z "${platformModel// }" ]]; then
-    platformModel="$NOT_SPECIFIED"
-fi
-platformModel=$(echo "$platformModel" | sed 's/^[ \t]*//;s/[ \t]*$//')
-platformModel=$(jsonPlatformModel "$platformModel")
+    if [[ -z "${platformModel// }" ]]; then
+        platformModel="$NOT_SPECIFIED"
+    fi
+    platformModel=$(echo "$platformModel" | sed 's/^[ \t]*//;s/[ \t]*$//')
+    platformModel=$(jsonPlatformModel "$platformModel")
 
-if [[ -z "${platformVersion// }" ]]; then
-    platformVersion="$NOT_SPECIFIED"
-fi
-platformVersion=$(echo "$platformVersion" | sed 's/^[ \t]*//;s/[ \t]*$//')
-platformVersion=$(jsonPlatformVersion "$platformVersion")
+    if [[ -z "${platformVersion// }" ]]; then
+        platformVersion="$NOT_SPECIFIED"
+    fi
+    platformVersion=$(echo "$platformVersion" | sed 's/^[ \t]*//;s/[ \t]*$//')
+    platformVersion=$(jsonPlatformVersion "$platformVersion")
 
-if ! [[ -z "${platformSerial// }" ]]; then
-    platformSerial=$(echo "$platformSerial" | sed 's/^[ \t]*//;s/[ \t]*$//')
-    platformSerial=$(jsonPlatformSerial "$platformSerial")
-fi
-platform=$(jsonPlatformObject "$platformManufacturer" "$platformModel" "$platformVersion" "$platformSerial")
+    if ! [[ -z "${platformSerial// }" ]]; then
+        platformSerial=$(echo "$platformSerial" | sed 's/^[ \t]*//;s/[ \t]*$//')
+        platformSerial=$(jsonPlatformSerial "$platformSerial")
+    fi
+    platform=$(jsonPlatformObject "$platformManufacturer" "$platformModel" "$platformVersion" "$platformSerial")
 
-
+    printf "$platform"
+}
 
 ### Gather component details
-dmidecodeParseTypeAssumeOneHandle "$SMBIOS_TYPE_CHASSIS"
-chassisClass=$(jsonComponentClass "$COMPCLASS_REGISTRY_TCG" "$COMPCLASS_CHASSIS")
-chassisManufacturer=$(dmidecodeGetString $(dmidecodeGetByte "0x4"))
-chassisModel=$(dmidecodeGetByte "0x5")
-chassisModel=$(printf "%d" "0x""$chassisModel") # Convert to decimal
-chassisSerial=$(dmidecodeGetString $(dmidecodeGetByte "0x7"))
-chassisRevision=$(dmidecodeGetString $(dmidecodeGetByte "0x6"))
-
-if [[ -z "${chassisManufacturer// }" ]]; then
-    chassisManufacturer="$NOT_SPECIFIED"
+platform=$(parseSystemData)
+smbiosRegistryData=""
+pcieRegistryData=""
+storageRegistryData=""
+tcgRegistryData=""
+if ! [[ -z "${INCLUDE_SMBIOS_REGISTRY// }" ]]; then
+    smbiosRegistryData=$($SMBIOS_REGISTRY_UTILITY --components-only)
 fi
-chassisManufacturer=$(echo "$chassisManufacturer" | sed 's/^[ \t]*//;s/[ \t]*$//')
-chassisManufacturer=$(jsonManufacturer "$chassisManufacturer")
-
-if [[ -z "${chassisModel// }" ]]; then
-    chassisModel="$NOT_SPECIFIED"
+if ! [[ -z "${INCLUDE_PCIE_REGISTRY// }" ]]; then
+    pcieRegistryData=$($PCIE_REGISTRY_UTILITY --components-only)
 fi
-chassisModel=$(echo "$chassisModel" | sed 's/^[ \t]*//;s/[ \t]*$//')
-chassisModel=$(jsonModel "$chassisModel")
-
-chassisOptional=""
-if ! [[ -z "${chassisSerial// }" ]]; then
-    chassisSerial=$(echo "$chassisSerial" | sed 's/^[ \t]*//;s/[ \t]*$//')
-    chassisSerial=$(jsonSerial "$chassisSerial")
-    chassisOptional="$chassisOptional"",""$chassisSerial"
+if ! [[ -z "${INCLUDE_STORAGE_REGISTRY// }" ]]; then
+    storageRegistryData=$($STORAGE_REGISTRY_UTILITY --components-only)
 fi
-if ! [[ -z "${chassisRevision// }" ]]; then
-    chassisRevision=$(echo "$chassisRevision" | sed 's/^[ \t]*//;s/[ \t]*$//')
-    chassisRevision=$(jsonRevision "$chassisRevision")
-    chassisOptional="$chassisOptional"",""$chassisRevision"
+if ! [[ -z "${INCLUDE_TCG_REGISTRY// }" ]]; then
+    source $TCG_REGISTRY_SCRIPT
+    tcgRegistryData=$(collectBasicRegistryComponents)
 fi
-chassisOptional=$(printf "$chassisOptional" | cut -c2-)
-componentChassis=$(jsonComponent "$chassisClass" "$chassisManufacturer" "$chassisModel" "$chassisOptional")
-
-### Gather baseboard details
-dmidecodeParseTypeAssumeOneHandle "$SMBIOS_TYPE_BASEBOARD"
-baseboardClass=$(jsonComponentClass "$COMPCLASS_REGISTRY_TCG" "$COMPCLASS_BASEBOARD")
-baseboardManufacturer=$(dmidecodeGetString $(dmidecodeGetByte "0x4"))
-baseboardModel=$(dmidecodeGetString $(dmidecodeGetByte "0x5"))
-baseboardSerial=$(dmidecodeGetString $(dmidecodeGetByte "0x7"))
-baseboardRevision=$(dmidecodeGetString $(dmidecodeGetByte "0x6"))
-baseboardFeatureFlags=$(dmidecodeGetByte "0x9")
-baseboardFeatureFlags=$(printf "%d" "0x""$baseboardFeatureFlags") # Convert to decimal
-baseboardReplaceableIndicator="28"
-baseboardFieldReplaceableAnswer="false"
-if (((baseboardFeatureFlags&baseboardReplaceableIndicator)!=0)); then
-    baseboardFieldReplaceableAnswer="true"
-fi
-baseboardFieldReplaceable=$(jsonFieldReplaceable "$baseboardFieldReplaceableAnswer")
-
-if [[ -z "${baseboardManufacturer// }" ]]; then
-    baseboardManufacturer="$NOT_SPECIFIED"
-fi
-baseboardManufacturer=$(echo "$baseboardManufacturer" | sed 's/^[ \t]*//;s/[ \t]*$//')
-baseboardManufacturer=$(jsonManufacturer "$baseboardManufacturer")
-
-if [[ -z "${baseboardModel// }" ]]; then
-    baseboardModel="$NOT_SPECIFIED"
-fi
-baseboardModel=$(echo "$baseboardModel" | sed 's/^[ \t]*//;s/[ \t]*$//')
-baseboardModel=$(jsonModel "$baseboardModel")
-
-baseboardOptional=""
-if ! [[ -z "${baseboardSerial// }" ]]; then
-    baseboardSerial=$(echo "$baseboardSerial" | sed 's/^[ \t]*//;s/[ \t]*$//')
-    baseboardSerial=$(jsonSerial "$baseboardSerial")
-    baseboardOptional="$baseboardOptional"",""$baseboardSerial"
-fi
-if ! [[ -z "${baseboardRevision// }" ]]; then
-    baseboardRevision=$(echo "$baseboardRevision" | sed 's/^[ \t]*//;s/[ \t]*$//')
-    baseboardRevision=$(jsonRevision "$baseboardRevision")
-    baseboardOptional="$baseboardOptional"",""$baseboardRevision"
-fi
-baseboardOptional=$(printf "$baseboardOptional" | cut -c2-)
-componentBaseboard=$(jsonComponent "$baseboardClass" "$baseboardManufacturer" "$baseboardModel" "$baseboardFieldReplaceable" "$baseboardOptional")
-
-### Gather BIOS details
-dmidecodeParseTypeAssumeOneHandle "$SMBIOS_TYPE_BIOS"
-biosClass=$(jsonComponentClass "$COMPCLASS_REGISTRY_TCG" "$COMPCLASS_BIOS")
-biosManufacturer=$(dmidecodeGetString $(dmidecodeGetByte "0x4"))
-biosModel=""
-biosSerial=""
-biosRevision=$(dmidecodeGetString $(dmidecodeGetByte "0x5"))
-
-if [[ -z "${biosManufacturer// }" ]]; then
-    biosManufacturer="$NOT_SPECIFIED"
-fi
-biosManufacturer=$(echo "$biosManufacturer" | sed 's/^[ \t]*//;s/[ \t]*$//')
-biosManufacturer=$(jsonManufacturer "$biosManufacturer")
-
-if [[ -z "${biosModel// }" ]]; then
-    biosModel="$NOT_SPECIFIED"
-fi
-biosModel=$(echo "$biosModel" | sed 's/^[ \t]*//;s/[ \t]*$//')
-biosModel=$(jsonModel "$biosModel")
-
-biosOptional=""
-if ! [[ -z "${biosSerial// }" ]]; then
-    biosSerial=$(echo "$biosSerial" | sed 's/^[ \t]*//;s/[ \t]*$//')
-    biosSerial=$(jsonSerial "$biosSerial")
-    biosOptional="$biosOptional"",""$biosSerial"
-fi
-if ! [[ -z "${biosRevision// }" ]]; then
-    biosRevision=$(echo "$biosRevision" | sed 's/^[ \t]*//;s/[ \t]*$//')
-    biosRevision=$(jsonRevision "$biosRevision")
-    biosOptional="$biosOptional"",""$biosRevision"
-fi
-biosOptional=$(printf "$biosOptional" | cut -c2-)
-componentBios=$(jsonComponent "$biosClass" "$biosManufacturer" "$biosModel" "$biosOptional")
-
-parseCpuData () {
-    dmidecodeHandles "$SMBIOS_TYPE_CPU"
-
-    notReplaceableIndicator="6"
-    tmpData=""
-    numHandles=$(dmidecodeNumHandles)
-    class=$(jsonComponentClass "$COMPCLASS_REGISTRY_TCG" "$COMPCLASS_CPU")
-
-    for ((i = 0 ; i < numHandles ; i++ )); do
-        dmidecodeParseHandle "${tableHandles[$i]}"
-
-    manufacturer=$(dmidecodeGetString $(dmidecodeGetByte "0x7"))
-    model=$(dmidecodeGetByte "0x6")
-        model=$(printf "%d" "0x""$model") # Convert to decimal
-    serial=$(dmidecodeGetString $(dmidecodeGetByte "0x20"))
-    revision=$(dmidecodeGetString $(dmidecodeGetByte "0x10"))
-        processorUpgrade=$(dmidecodeGetByte "0x19")
-        processorUpgrade=$(printf "%d" "0x""$processorUpgrade") # Convert to decimal
-
-    if [[ -z "${manufacturer// }" ]]; then
-        manufacturer="$NOT_SPECIFIED"
-    fi
-    manufacturer=$(echo "$manufacturer" | sed 's/^[ \t]*//;s/[ \t]*$//')
-    manufacturer=$(jsonManufacturer "$manufacturer")
-
-    if [[ -z "${model// }" ]]; then
-        model="$NOT_SPECIFIED"
-    fi
-    model=$(echo "$model" | sed 's/^[ \t]*//;s/[ \t]*$//')
-    model=$(jsonModel "$model")
-
-    optional=""
-    if ! [[ -z "${serial// }" ]]; then
-        serial=$(echo "$serial" | sed 's/^[ \t]*//;s/[ \t]*$//')
-        serial=$(jsonSerial "$serial")
-        optional="$optional"",""$serial"
-    fi
-    if ! [[ -z "${revision// }" ]]; then
-        revision=$(echo "$revision" | sed 's/^[ \t]*//;s/[ \t]*$//')
-        revision=$(jsonRevision "$revision")
-        optional="$optional"",""$revision"
-    fi
-    optional=$(printf "$optional" | cut -c2-)
-
-        replaceable="true"
-        if [ $processorUpgrade -eq $notReplaceableIndicator ]; then
-            replaceable="false"
-        fi
-        replaceable=$(jsonFieldReplaceable "$replaceable")
-
-        newCpuData=$(jsonComponent "$class" "$manufacturer" "$model" "$replaceable" "$optional")
-        tmpData="$tmpData"",""$newCpuData"
-    done
-
-    # remove leading comma
-    tmpData=$(printf "$tmpData" | cut -c2-)
-
-    printf "$tmpData"
-}
-
-parseRamData () {
-    dmidecodeHandles "$SMBIOS_TYPE_RAM"
-
-    replaceable=$(jsonFieldReplaceable "true")
-    tmpData=""
-    numHandles=$(dmidecodeNumHandles)
-    class=$(jsonComponentClass "$COMPCLASS_REGISTRY_TCG" "$COMPCLASS_RAM")
-
-    for ((i = 0 ; i < numHandles ; i++ )); do
-        dmidecodeParseHandle "${tableHandles[$i]}"
-
-    manufacturer=$(dmidecodeGetString $(dmidecodeGetByte "0x17"))
-    model=$(dmidecodeGetString $(dmidecodeGetByte "0x1A"))
-    serial=$(dmidecodeGetString $(dmidecodeGetByte "0x18"))
-    revision=$(dmidecodeGetString $(dmidecodeGetByte "0x19"))
-
-        if ([[ -z "${manufacturer// }" ]] && [[ -z "${model// }" ]] && [[ -z "${serial// }" ]] && [[ -z "${revision// }" ]]); then
-            continue
-        fi
-
-    if [[ -z "${manufacturer// }" ]]; then
-        manufacturer="$NOT_SPECIFIED"
-    fi
-    manufacturer=$(echo "$manufacturer" | sed 's/^[ \t]*//;s/[ \t]*$//')
-    manufacturer=$(jsonManufacturer "$manufacturer")
-
-    if [[ -z "${model// }" ]]; then
-        model="$NOT_SPECIFIED"
-    fi
-    model=$(echo "$model" | sed 's/^[ \t]*//;s/[ \t]*$//')
-    model=$(jsonModel "$model")
-
-    optional=""
-    if ! [[ -z "${serial// }" ]]; then
-        serial=$(echo "$serial" | sed 's/^[ \t]*//;s/[ \t]*$//')
-        serial=$(jsonSerial "$serial")
-        optional="$optional"",""$serial"
-    fi
-    if ! [[ -z "${revision// }" ]]; then
-        revision=$(echo "$revision" | sed 's/^[ \t]*//;s/[ \t]*$//')
-        revision=$(jsonRevision "$revision")
-        optional="$optional"",""$revision"
-    fi
-    optional=$(printf "$optional" | cut -c2-)
-
-        newRamData=$(jsonComponent "$class" "$manufacturer" "$model" "$replaceable" "$optional")
-        tmpData="$tmpData"",""$newRamData"
-    done
-
-    # remove leading comma
-    tmpData=$(printf "$tmpData" | cut -c2-)
-
-    printf "$tmpData"
-}
-
-# Write script to parse multiple responses
-# Network:
-# lshw description: type of address.
-#                 : Ethernet interface, Wireless interface, Bluetooth wireless interface
-#           vendor: manufacturer
-#          product: model
-#           serial: address & serial number
-#          version: revision
-#
-# Example:
-# ADDRESS1=$(jsonEthernetMac "AB:CD:EE:EE:DE:34")
-# ADDR_LIST=$(jsonAddress "$ADDRESS1" "$ADDRESS2")
-parseNicData () {
-    lshwNetwork
-
-    replaceable=$(jsonFieldReplaceable "true")
-    tmpData=""
-    numHandles=$(lshwNumBusItems)
-    class=$(jsonComponentClass "$COMPCLASS_REGISTRY_TCG" "$COMPCLASS_NIC")
-
-    for ((i = 0 ; i < numHandles ; i++ )); do
-        manufacturer=$(lshwGetVendorIDFromBusItem "$i")
-        model=$(lshwGetProductIDFromBusItem "$i")
-        serialConstant=$(lshwGetLogicalNameFromBusItem "$i")
-        serialConstant=$(ethtoolPermAddr "$serialConstant")
-        serialConstant=$(standardizeMACAddr "${serialConstant}")
-        serial=""
-        revision=$(lshwGetVersionFromBusItem "$i")
-
-        if [[ -z "${manufacturer// }" ]] && [[ -z "${model// }" ]] && (! [[ -z "${serialConstant// }" ]] || ! [[ -z "${revision// }" ]]); then
-            manufacturer=$(lshwGetVendorNameFromBusItem "$i")
-        model=$(lshwGetProductNameFromBusItem "$i")
-        fi
-
-    if [[ -z "${manufacturer// }" ]]; then
-        manufacturer="$NOT_SPECIFIED"
-    fi
-    manufacturer=$(echo "$manufacturer" | sed 's/^[ \t]*//;s/[ \t]*$//')
-    manufacturer=$(jsonManufacturer "$manufacturer")
-
-    if [[ -z "${model// }" ]]; then
-        model="$NOT_SPECIFIED"
-    fi
-    model=$(echo "$model" | sed 's/^[ \t]*//;s/[ \t]*$//')
-    model=$(jsonModel "$model")
-
-    optional=""
-    if ! [[ -z "${serialConstant// }" ]]; then
-        serial=$(echo "$serialConstant" | sed 's/^[ \t]*//;s/[ \t]*$//')
-        serial=$(jsonSerial "$serialConstant")
-        optional="$optional"",""$serial"
-    fi
-    if ! [[ -z "${revision// }" ]]; then
-        revision=$(echo "$revision" | sed 's/^[ \t]*//;s/[ \t]*$//' | awk '{ print toupper($0) }')
-        revision=$(jsonRevision "$revision")
-        optional="$optional"",""$revision"
-    fi
-        bluetoothCap=$(lshwBusItemBluetoothCap "$i")
-        ethernetCap=$(lshwBusItemEthernetCap "$i")
-        wirelessCap=$(lshwBusItemWirelessCap "$i")
-
-        if ([ -n "$bluetoothCap" ] || [ -n "$ethernetCap" ] || [ -n "$wirelessCap" ]) && ! [[ -z "${serialConstant// }" ]]; then
-            thisAddress=
-            if [ -n "$wirelessCap" ]; then
-                thisAddress=$(jsonWlanMac "$serialConstant")
-            elif [ -n "$bluetoothCap" ]; then
-                thisAddress=$(jsonBluetoothMac "$serialConstant")
-            elif [ -n "$ethernetCap" ]; then
-                thisAddress=$(jsonEthernetMac "$serialConstant")
-            fi
-            if [ -n "$thisAddress" ]; then
-                thisAddress=$(jsonAddress "$thisAddress")
-                optional="$optional"",""$thisAddress"
-            fi
-        fi
-    optional=$(printf "$optional" | cut -c2-)
-
-        newNicData=$(jsonComponent "$class" "$manufacturer" "$model" "$replaceable" "$optional")
-        tmpData="$tmpData"",""$newNicData"
-    done
-
-    # remove leading comma
-    tmpData=$(printf "$tmpData" | cut -c2-)
-
-    printf "$tmpData"
-}
-
-parseHddData () {
-    lshwDisk
-
-    replaceable=$(jsonFieldReplaceable "true")
-    tmpData=""
-    numHandles=$(lshwNumBusItems)
-    class=$(jsonComponentClass "$COMPCLASS_REGISTRY_TCG" "$COMPCLASS_HDD")
-
-    for ((i = 0 ; i < numHandles ; i++ )); do
-        manufacturer=$(lshwGetVendorIDFromBusItem "$i")
-        model=$(lshwGetProductIDFromBusItem "$i")
-        serial=$(lshwGetSerialFromBusItem "$i")
-        revision=$(lshwGetVersionFromBusItem "$i")
-
-        if [[ -z "${manufacturer// }" ]] && [[ -z "${model// }" ]] && (! [[ -z "${serial// }" ]] || ! [[ -z "${revision// }" ]]); then
-            model=$(lshwGetProductNameFromBusItem "$i")
-            manufacturer=""
-            revision="" # Seeing inconsistent behavior cross-OS for this case, will return
-        fi
-
-    if [[ -z "${manufacturer// }" ]]; then
-        manufacturer="$NOT_SPECIFIED"
-    fi
-    manufacturer=$(echo "$manufacturer" | sed 's/^[ \t]*//;s/[ \t]*$//')
-    manufacturer=$(jsonManufacturer "$manufacturer")
-
-    if [[ -z "${model// }" ]]; then
-        model="$NOT_SPECIFIED"
-    fi
-    model=$(echo "$model" | sed 's/^[ \t]*//;s/[ \t]*$//')
-    model=$(jsonModel "$model")
-
-    optional=""
-    if ! [[ -z "${serial// }" ]]; then
-        serial=$(echo "$serial" | sed 's/^[ \t]*//;s/[ \t]*$//')
-        serial=$(jsonSerial "$serial")
-        optional="$optional"",""$serial"
-    fi
-    if ! [[ -z "${revision// }" ]]; then
-        revision=$(echo "$revision" | sed 's/^[ \t]*//;s/[ \t]*$//' | awk '{ print toupper($0) }')
-        revision=$(jsonRevision "$revision")
-        optional="$optional"",""$revision"
-    fi
-    optional=$(printf "$optional" | cut -c2-)
-
-        newHddData=$(jsonComponent "$class" "$manufacturer" "$model" "$replaceable" "$optional")
-        tmpData="$tmpData"",""$newHddData"
-    done
-
-    # remove leading comma
-    tmpData=$(printf "$tmpData" | cut -c2-)
-
-    printf "$tmpData"
-}
-
-parseNvmeData () {
-    nvmeParse
-
-    replaceable=$(jsonFieldReplaceable "true")
-    tmpData=""
-    numHandles=$(nvmeNumDevices)
-    class=$(jsonComponentClass "$COMPCLASS_REGISTRY_TCG" "$COMPCLASS_HDD")
-
-    for ((i = 0 ; i < numHandles ; i++ )); do
-        manufacturer="" # Making this appear as it does on windows, nvme-cli doesn't return a manufacturer field
-        model=$(nvmeGetModelNumberForDevice "$i")
-        serial=$(nvmeGetNguidForDevice "$i")
-        if [[ $serial =~ ^[0]+$ ]]; then
-            serial=$(nvmeGetEuiForDevice "$i")
-        fi
-        revision="" # empty for a similar reason to the manufacturer field
-
-    if [[ -z "${manufacturer// }" ]]; then
-        manufacturer="$NOT_SPECIFIED"
-    fi
-    manufacturer=$(echo "$manufacturer" | sed 's/^[ \t]*//;s/[ \t]*$//')
-    manufacturer=$(jsonManufacturer "$manufacturer")
-
-    if [[ -z "${model// }" ]]; then
-        model="$NOT_SPECIFIED"
-    fi
-    model=$(echo "${model:0:16}" | sed 's/^[ \t]*//;s/[ \t]*$//') # limited to 16 characters for compatibility to windows, then trimmed
-    model=$(jsonModel "$model")
-
-    optional=""
-    if ! [[ -z "${serial// }" ]]; then
-        serial=$(echo "${serial^^}" | sed 's/^[ \t]*//;s/[ \t]*$//' | sed 's/.\{4\}/&_/g' | sed 's/_$/\./')
-        serial=$(jsonSerial "$serial")
-        optional="$optional"",""$serial"
-    fi
-    optional=$(printf "$optional" | cut -c2-)
-
-        newHddData=$(jsonComponent "$class" "$manufacturer" "$model" "$replaceable" "$optional")
-        tmpData="$tmpData"",""$newHddData"
-    done
-
-    # remove leading comma
-    tmpData=$(printf "$tmpData" | cut -c2-)
-
-    printf "$tmpData"
-}
-
-parseGfxData () {
-    lshwDisplay
-
-    replaceable=$(jsonFieldReplaceable "true")
-    tmpData=""
-    numHandles=$(lshwNumBusItems)
-    class=$(jsonComponentClass "$COMPCLASS_REGISTRY_TCG" "$COMPCLASS_GFX")
-
-    for ((i = 0 ; i < numHandles ; i++ )); do
-        manufacturer=$(lshwGetVendorIDFromBusItem "$i")
-    model=$(lshwGetProductIDFromBusItem "$i")
-    serial=$(lshwGetSerialFromBusItem "$i")
-    revision=$(lshwGetVersionFromBusItem "$i")
-
-        if [[ -z "${manufacturer// }" ]] && [[ -z "${model// }" ]] && (! [[ -z "${serial// }" ]] || ! [[ -z "${revision// }" ]]); then
-            manufacturer=$(lshwGetVendorNameFromBusItem "$i")
-            model=$(lshwGetProductNameFromBusItem "$i")
-        fi
-
-    if [[ -z "${manufacturer// }" ]]; then
-        manufacturer="$NOT_SPECIFIED"
-    fi
-    manufacturer=$(echo "$manufacturer" | sed 's/^[ \t]*//;s/[ \t]*$//')
-    manufacturer=$(jsonManufacturer "$manufacturer")
-
-    if [[ -z "${model// }" ]]; then
-        model="$NOT_SPECIFIED"
-    fi
-    model=$(echo "$model" | sed 's/^[ \t]*//;s/[ \t]*$//')
-    model=$(jsonModel "$model")
-
-    optional=""
-    if ! [[ -z "${serial// }" ]]; then
-        serial=$(echo "$serial" | sed 's/^[ \t]*//;s/[ \t]*$//')
-        serial=$(jsonSerial "$serial")
-        optional="$optional"",""$serial"
-    fi
-    if ! [[ -z "${revision// }" ]]; then
-        revision=$(echo "$revision" | sed 's/^[ \t]*//;s/[ \t]*$//' | awk '{ print toupper($0) }')
-        revision=$(jsonRevision "$revision")
-        optional="$optional"",""$revision"
-    fi
-    optional=$(printf "$optional" | cut -c2-)
-
-        newGfxData=$(jsonComponent "$class" "$manufacturer" "$model" "$replaceable" "$optional")
-        tmpData="$tmpData"",""$newGfxData"
-    done
-
-    # remove leading comma
-    tmpData=$(printf "$tmpData" | cut -c2-)
-
-    printf "$tmpData"
-}
-
+componentArray=$(jsonComponentArray "$smbiosRegistryData" "$pcieRegistryData" "$storageRegistryData" "$tcgRegistryData")
 
 ### Gather property details
 property1=$(jsonProperty "uname -r" "$(uname -r)")  ## Example1
 property2=$(jsonProperty "OS Release" "$(grep 'PRETTY_NAME=' /etc/os-release | sed 's/[^=]*=//' | sed -e 's/^[[:space:]\"]*//' | sed -e 's/[[:space:]\"]*$//')") # "$JSON_STATUS_ADDED") ## Example2 with optional third status argument
-
-### Collate the component details
-componentsCPU=$(parseCpuData)
-componentsRAM=$(parseRamData)
-componentsNIC=$(parseNicData)
-componentsHDD=$(parseHddData)
-componentsNVMe=$(parseNvmeData)
-componentsGFX=$(parseGfxData)
-componentArray=$(jsonComponentArray "$componentChassis" "$componentBaseboard" "$componentBios" "$componentsCPU" "$componentsRAM" "$componentsNIC" "$componentsHDD" "$componentsNVMe" "$componentsGFX")
 
 ### Collate the property details
 propertyArray=$(jsonPropertyArray "$property1" "$property2")

--- a/scripts/hw.sh
+++ b/scripts/hw.sh
@@ -2,7 +2,7 @@
 lshwParse () {
     type="${1}"
     str=$(lshw -c "$type" -numeric)
-    numLines=$(printf "$str" | wc -l)
+    numLines=$(printf "%s" "$str" | wc -l)
     items=()
     busitems=()
     
@@ -12,11 +12,11 @@ lshwParse () {
     while read -r line; do
         lineItr=$((lineItr+1))
         lastLine=""
-        if (($lineItr > $numLines)); then 
+        if ((lineItr > numLines)); then
             parsing+="$line"$'\n'
             lastLine="1"
         fi
-        if (printf "$line" | grep --quiet -e "^[[:space:]]*\*-.*[[:space:]]*$") || [ -n "$lastLine" ]; then
+        if (printf "%s" "$line" | grep --quiet -e "^[[:space:]]*\*-.*[[:space:]]*$") || [ -n "$lastLine" ]; then
             if [ -n "$parsing" ]; then
                 items+=("${parsing}")
             fi
@@ -28,11 +28,11 @@ lshwParse () {
     numItemsDec=$(printf "%d" "0x"${#items[@]})
     for ((i = 0 ; i < numItemsDec ; i++ )); do
         matchesType=""
-        if (printf "${items[$i]}" | grep --quiet -e "^\*-"$type":\?[0-9A-Fa-f]*[[:space:]]*\(DISABLED\)\?$"); then
+        if (printf "%s" "${items[$i]}" | grep --quiet -e "^\*-$type:\?[0-9A-Fa-f]*[[:space:]]*\(DISABLED\)\?$"); then
             matchesType="1"
         fi
         isPhysical=""
-        if (printf "${items[$i]}" | grep --quiet -e "^bus info:.*$"); then
+        if (printf "%s" "${items[$i]}" | grep --quiet -e "^bus info:.*$"); then
             isPhysical="1"
         fi
 
@@ -51,105 +51,105 @@ lshwNetwork () {
     lshwParse "network"
 }
 lshwNumBusItems () {
-    printf "${#busitems[@]}"
+    printf "%s" "${#busitems[@]}"
 }
 lshwGetVendorIDFromBusItem () {
-    itemnumber="${1}"
+    itemNumber="${1}"
     result=""
-    str=$(echo "${busitems[$itemnumber]}" | grep -e "^vendor:.*[^\[]\[.\+$" | sed 's/^vendor:.*[^\[]\[\([0-9A-Fa-f]\+\)\]$/\1/')
+    str=$(echo "${busitems[$itemNumber]}" | grep -e "^vendor:.*[^\[]\[.\+$" | sed 's/^vendor:.*[^\[]\[\([0-9A-Fa-f]\+\)\]$/\1/')
     if [ -n "$str" ]; then
         result="0000$str"
         result="${result: -4}"
     fi
-    printf "$result"
+    printf "%s" "$result"
 }
 lshwGetProductIDFromBusItem () {
-    itemnumber="${1}"
+    itemNumber="${1}"
     result=""
-    str=$(echo "${busitems[$itemnumber]}" | grep -e "^product:.*[^\[]\[.\+$" | sed 's/^product:.*[^\[]\[[0-9A-Fa-f]\+:\([0-9A-Fa-f]\+\)\]$/\1/')
+    str=$(echo "${busitems[$itemNumber]}" | grep -e "^product:.*[^\[]\[.\+$" | sed 's/^product:.*[^\[]\[[0-9A-Fa-f]\+:\([0-9A-Fa-f]\+\)\]$/\1/')
     if [ -n "$str" ]; then
         result="0000$str"
         result="${result: -4}"
     fi
-    printf "$result"
+    printf "%s" "$result"
 }
 lshwGetVersionFromBusItem () {
-    itemnumber="${1}"
+    itemNumber="${1}"
     result=""
-    str=$(echo "${busitems[$itemnumber]}" | grep -e "^version:.*$" | sed 's/^version: \([0-9A-Za-z]\+\)$/\1/')
+    str=$(echo "${busitems[$itemNumber]}" | grep -e "^version:.*$" | sed 's/^version: \([0-9A-Za-z]\+\)$/\1/')
     if [ -n "$str" ]; then
         result=$str
     fi
-    printf "$result"
+    printf "%s" "$result"
 }
 lshwGetSerialFromBusItem () {
-    itemnumber="${1}"
+    itemNumber="${1}"
     result=""
-    str=$(echo "${busitems[$itemnumber]}" | grep -e "^serial:.*$" | sed 's/^serial: \([0-9A-Za-z:-]\+\)$/\1/')
+    str=$(echo "${busitems[$itemNumber]}" | grep -e "^serial:.*$" | sed 's/^serial: \([0-9A-Za-z:-]\+\)$/\1/')
     if [ -n "$str" ]; then
         result=$str
     fi
-    printf "$result"
+    printf "%s" "$result"
 }
 lshwGetLogicalNameFromBusItem () {
-    itemnumber="${1}"
+    itemNumber="${1}"
     result=""
-    str=$(echo "${busitems[$itemnumber]}" | grep -e "^logical name:.*$" | sed 's/^logical name: \(.\+\)$/\1/')
+    str=$(echo "${busitems[$itemNumber]}" | grep -e "^logical name:.*$" | sed 's/^logical name: \(.\+\)$/\1/')
     if [ -n "$str" ]; then
         result=$str
     fi
-    printf "$result"
+    printf "%s" "$result"
 }
 lshwGetVendorNameFromBusItem () {
-    itemnumber="${1}"
+    itemNumber="${1}"
     result=""
-    str=$(echo "${busitems[$itemnumber]}" | grep -e "^vendor:.*$" | sed 's/^vendor: \([0-9A-Za-z -]\+\) \?\[\?.*$/\1/')
+    str=$(echo "${busitems[$itemNumber]}" | grep -e "^vendor:.*$" | sed 's/^vendor: \([0-9A-Za-z -]\+\) \?\[\?.*$/\1/')
     if [ -n "$str" ]; then
         result=$str
     fi
-    printf "$result"
+    printf "%s" "$result"
 }
 lshwGetProductNameFromBusItem () {
-    itemnumber="${1}"
+    itemNumber="${1}"
     result=""
-    str=$(echo "${busitems[$itemnumber]}" | grep -e "^product:.*$" | sed 's/^product: \([0-9A-Za-z\(\) -]\+\) \?\[\?.*$/\1/')
+    str=$(echo "${busitems[$itemNumber]}" | grep -e "^product:.*$" | sed 's/^product: \([0-9A-Za-z\(\) -]\+\) \?\[\?.*$/\1/')
     if [ -n "$str" ]; then
         result=$str
     fi
-    printf "$result"
+    printf "%s" "$result"
 }
 lshwBusItemBluetoothCap () {
-    itemnumber="${1}"
+    itemNumber="${1}"
     result=""
-    if (echo "${busitems[$itemnumber]}" | grep --quiet "capabilities.*bluetooth"); then
+    if (echo "${busitems[$itemNumber]}" | grep --quiet "capabilities.*bluetooth"); then
         result="1"
     fi
-    printf "$result"
+    printf "%s" "$result"
 }
 lshwBusItemEthernetCap () {
-    itemnumber="${1}"
+    itemNumber="${1}"
     result=""
-    if (echo "${busitems[$itemnumber]}" | grep --quiet "capabilities.*ethernet"); then
+    if (echo "${busitems[$itemNumber]}" | grep --quiet "capabilities.*ethernet"); then
         result="1"
     fi
-    printf "$result"
+    printf "%s" "$result"
 }
 lshwBusItemWirelessCap () {
-    itemnumber="${1}"
+    itemNumber="${1}"
     result=""
-    if (echo "${busitems[$itemnumber]}" | grep --quiet "capabilities.*wireless"); then
+    if (echo "${busitems[$itemNumber]}" | grep --quiet "capabilities.*wireless"); then
         result="1"
     fi
-    printf "$result"
+    printf "%s" "$result"
 }
 ethtoolPermAddr () {
     iface="${1}"
     str=$(ethtool -P "$iface" 2> /dev/null | grep -e "^Perm.*$" | sed 's/^Permanent address: \([0-9a-f:]\+\)$/\1/')
-    printf "$str"
+    printf "%s" "$str"
 }
 standardizeMACAddr () {
-    mac=$(printf "${1}" | tr -d "[[:space:]]:-" | awk '{ print toupper($0) }')
-    printf "$mac"
+    mac=$(printf "%s" "${1}" | tr -d "[[:space:]]:-" | awk '{ print toupper($0) }')
+    printf "%s" "$mac"
 }
 #lshwParse "disk"
 #lshwNetwork
@@ -160,8 +160,8 @@ standardizeMACAddr () {
 #prod=$(lshwGetProductIDFromBusItem "0")
 #rev=$(lshwGetVersionFromBusItem "0")
 #serial=$(lshwGetSerialFromBusItem "0")
-#venname=$(lshwGetVendorNameFromBusItem "0")
-#prodname=$(lshwGetProductNameFromBusItem "0")
+#venName=$(lshwGetVendorNameFromBusItem "0")
+#prodName=$(lshwGetProductNameFromBusItem "0")
 #bluetoothCap=$(lshwBusItemBluetoothCap)
 #ethernetCap=$(lshwBusItemEthernetCap)
 #wirelessCap=$(lshwBusItemWirelessCap)
@@ -169,8 +169,8 @@ standardizeMACAddr () {
 #echo $prod
 #echo $rev
 #echo $serial
-#echo $venname
-#echo $prodname
+#echo $venName
+#echo $prodName
 #echo $bluetoothCap
 #echo $ethernetCap
 #echo $wirelessCap

--- a/scripts/json.sh
+++ b/scripts/json.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 
 ### User customizable values
-APP_HOME="`dirname "$0"`"
+APP_HOME=$(dirname "$0")
 ENTERPRISE_NUMBERS_FILE="$APP_HOME""/enterprise-numbers"
 PEN_ROOT="1.3.6.1.4.1." # OID root for the private enterprise numbers
 
@@ -46,9 +46,13 @@ JSON_NAME="PROPERTYNAME"
 JSON_VALUE="PROPERTYVALUE"
 JSON_PROP_STATUS="PROPERTYSTATUS"
 #### JSON Status Keywords
+# shellcheck disable=SC2034
 JSON_STATUS_ADDED="ADDED"
+# shellcheck disable=SC2034
 JSON_STATUS_MODIFIED="MODIFIED"
+# shellcheck disable=SC2034
 JSON_STATUS_REMOVED="REMOVED"
+# shellcheck disable=SC2034
 NOT_SPECIFIED="Not Specified"
 
 
@@ -102,22 +106,27 @@ JSON_COMPONENTCLASS_TEMPLATE=' \"'"$JSON_COMPONENTCLASS"'\": {
         \"'"$JSON_COMPONENTCLASSREGISTRY"'\": \"%s\",
         \"'"$JSON_COMPONENTCLASSVALUE"'\": \"%s\"
     }'
+# shellcheck disable=SC2034
 JSON_ATTRIBUTECERTIDENTIFIER_TEMPLATE=' \"'"$JSON_ATTRIBUTECERTIDENTIFIER"'\": {
         \"'"$JSON_HASHALG"'\": \"%s\",
         \"'"$JSON_HASHVALUE"'\": \"%s\"
     },'
+# shellcheck disable=SC2034
 JSON_GENERICCERTIDENTIFIER_TEMPLATE=' \"'"$JSON_GENERICCERTIDENTIFIER"'\": {
         \"'"$JSON_ISSUER"'\": \"%s\",
         \"'"$JSON_SERIAL"'\": \"%s\"
     },'
+# shellcheck disable=SC2034
 JSON_COMPONENTPLATFORMCERT_TEMPLATE='
     \"'"$JSON_COMPONENTPLATFORMCERT"'\": {
         %s
     }'
+# shellcheck disable=SC2034
 JSON_COMPONENTPLATFORMCERTURI_TEMPLATE='
     \"'"$JSON_COMPONENTPLATFORMCERTURI"'\": {
         %s
     }'
+# shellcheck disable=SC2034
 JSON_STATUS_TEMPLATE='
     \"'"$JSON_STATUS"'\": {
 
@@ -125,6 +134,8 @@ JSON_STATUS_TEMPLATE='
 
 ### JSON Constructor Aides
 jsonComponentClass () {
+    # variable contains the format string
+    # shellcheck disable=SC2059
     printf "$JSON_COMPONENTCLASS_TEMPLATE" "${1}" "${2}"
 }
 jsonManufacturer () {
@@ -134,7 +145,7 @@ jsonManufacturer () {
     #    tmpManufacturerId=$(jsonManufacturerId "$tmpManufacturerId")
     #    manufacturer="$manufacturer"",""$tmpManufacturerId"
     #fi
-    printf "$manufacturer"
+    printf "%s" "$manufacturer"
 }
 jsonModel () {
     printf '\"'"$JSON_MODEL"'\": \"%s\"' "${1}"
@@ -152,12 +163,18 @@ jsonFieldReplaceable () {
     printf '\"'"$JSON_FIELDREPLACEABLE"'\": \"%s\"' "${1}"
 }
 jsonEthernetMac () {
+    # variable contains the format string
+    # shellcheck disable=SC2059
     printf "$JSON_ETHERNETMAC_TEMPLATE" "${1}"
 }
 jsonWlanMac () {
+    # variable contains the format string
+    # shellcheck disable=SC2059
     printf "$JSON_WLANMAC_TEMPLATE" "${1}"
 }
 jsonBluetoothMac () {
+    # variable contains the format string
+    # shellcheck disable=SC2059
     printf "$JSON_BLUETOOTHMAC_TEMPLATE" "${1}"
 }
 jsonPlatformModel () {
@@ -170,7 +187,7 @@ jsonPlatformManufacturerStr () {
     #    tmpManufacturerId=$(jsonPlatformManufacturerId "$tmpManufacturerId")
     #    manufacturer="$manufacturer"",""$tmpManufacturerId"
     #fi
-    printf "$manufacturer"
+    printf "%s" "$manufacturer"
 }
 jsonPlatformVersion () {
     printf '\"'"$JSON_PLATFORMVERSION"'\": \"%s\"' "${1}"
@@ -182,14 +199,18 @@ jsonPlatformManufacturerId () {
     printf '\"'"$JSON_PLATFORMMANUFACTURERID"'\": \"%s\"' "${1}"
 }
 queryForPen () {
-    pen=$(grep -B 1 "^[ \t]*""${1}""$" "$ENTERPRISE_NUMBERS_FILE" | sed -n '1p' | tr -d [:space:])
+    pen=$(grep -B 1 "^[ \t]*""${1}""$" "$ENTERPRISE_NUMBERS_FILE" | sed -n '1p' | tr -d '[:space:]')
     printf "%s%s" "$PEN_ROOT" "$pen"
 }
 jsonProperty () {
     if [ -n "${1}" ] && [ -n "${2}" ]; then
         if [ -n "${3}" ]; then
+            # variable contains the format string
+            # shellcheck disable=SC2059
             printf "$JSON_PROPERTY_TEMPLATE_OPT" "${1}" "${2}" "${3}"
         else
+            # variable contains the format string
+            # shellcheck disable=SC2059
             printf "$JSON_PROPERTY_TEMPLATE" "${1}" "${2}"
         fi
     fi
@@ -204,57 +225,78 @@ jsonHashValue () {
     printf '\"'"$JSON_HASHVALUE"'\": \"%s\"' "${1}"
 }
 toCSV () {
-    old="$IFS"
-    IFS=','
+    local value=""
+    local IFS=','
     value="$*"
-    value=$(printf "$value" | tr -s , | sed -e '1s/^[,]*//' | sed -e '$s/[,]*$//')
-    printf "$value"
+    # trim leading and trailing commas
+    value=$(printf "%s" "$value" | tr -s , | sed -e '1s/^[,]*//' | sed -e '$s/[,]*$//')
+    printf "%s" "$value"
 }
 jsonAddress () {
+    # variable contains the format string
+    # shellcheck disable=SC2059
     printf "$JSON_ADDRESSES_TEMPLATE" "$(toCSV "$@")"
 }
 jsonComponent () {
+    # variable contains the format string
+    # shellcheck disable=SC2059
     printf "$JSON_COMPONENT_TEMPLATE" "$(toCSV "$@")"
 }
 jsonComponentArray () {
+    # variable contains the format string
+    # shellcheck disable=SC2059
     printf "$JSON_COMPONENT_ARRAY_TEMPLATE" "$(toCSV "$@")"
 }
 jsonPropertyArray () {
     if [ "$#" -ne 0 ]; then
+        # variable contains the format string
+        # shellcheck disable=SC2059
         printf "$JSON_PROPERTY_ARRAY_TEMPLATE" "$(toCSV "$@")"
     fi
 }
 jsonPlatformObject () {
+    # variable contains the format string
+    # shellcheck disable=SC2059
     printf "$JSON_PLATFORM_TEMPLATE" "$(toCSV "$@")"
 }
 jsonComponentsUri () {
-    if [ -n "$COMPONENTS_URI" ]; then
+    COMPONENTS_URI="$1"
+    COMPONENTS_URI_LOCAL_COPY_FOR_HASH="$2"
+    if [[ -n "$COMPONENTS_URI" && "$COMPONENTS_URI" != *[[:space:]]* ]]; then
         componentsUri=$(jsonUri "$COMPONENTS_URI")
         componentsUriDetails=""
-        if [ -n "$PROPERTIES_URI_LOCAL_COPY_FOR_HASH" ]; then
+        if [[ -n "$COMPONENTS_URI_LOCAL_COPY_FOR_HASH" && "$COMPONENTS_URI_LOCAL_COPY_FOR_HASH" != *[[:space:]]* && -f "$COMPONENTS_URI_LOCAL_COPY_FOR_HASH" ]]; then
             hashAlg="2.16.840.1.101.3.4.2.1" # SHA256, see https://tools.ietf.org/html/rfc5754 for other common hash algorithm IDs
-            hashValue=$(sha256sum "$COMPONENTS_URI_LOCAL_COPY_FOR_HASH" | sed -r 's/^([0-9a-f]+).*/\1/' | tr -d [:space:] | xxd -r -p | base64 -w 0)
+            hashValue=$(sha256sum "$COMPONENTS_URI_LOCAL_COPY_FOR_HASH" | sed -r 's/^([0-9a-f]+).*/\1/' | tr -d '[:space:]' | xxd -r -p | base64 -w 0)
+            hashAlgStr=$(jsonHashAlg "$hashAlg")
+            hashValueStr=$(jsonHashValue "$hashValue")
+            componentsUriDetails="$hashAlgStr"",""$hashValueStr"
+        fi
+        # variable contains the format string
+        # shellcheck disable=SC2059
+        printf "$JSON_COMPONENTSURI_TEMPLATE" "$(toCSV "$componentsUri" "$componentsUriDetails")"
+    fi
+}
+jsonPropertiesUri () {
+    PROPERTIES_URI="$1"
+    PROPERTIES_URI_LOCAL_COPY_FOR_HASH="$2"
+    if [[ -n "$PROPERTIES_URI" && "$PROPERTIES_URI" != *[[:space:]]* ]]; then
+        propertiesUri=$(jsonUri "$PROPERTIES_URI")
+        propertiesUriDetails=""
+        if [[ -n "$PROPERTIES_URI_LOCAL_COPY_FOR_HASH" && "$PROPERTIES_URI_LOCAL_COPY_FOR_HASH" != *[[:space:]]* && -f "$PROPERTIES_URI_LOCAL_COPY_FOR_HASH" ]]; then
+            hashAlg="2.16.840.1.101.3.4.2.1" # SHA256, see https://tools.ietf.org/html/rfc5754 for other common hash algorithm IDs
+            hashValue=$(sha256sum "$PROPERTIES_URI_LOCAL_COPY_FOR_HASH" | sed -r 's/^([0-9a-f]+).*/\1/' | tr -d '[:space:]' | xxd -r -p | base64 -w 0)
             hashAlgStr=$(jsonHashAlg "$hashAlg")
             hashValueStr=$(jsonHashValue "$hashValue")
             propertiesUriDetails="$hashAlgStr"",""$hashValueStr"
         fi
-    printf "$JSON_COMPONENTSURI_TEMPLATE" "$(toCSV "$componentsUri" "$componentsUriDetails")"
-    fi
-}
-jsonPropertiesUri () {
-    if [ -n "$PROPERTIES_URI" ]; then
-        propertiesUri=$(jsonUri "$PROPERTIES_URI")
-        propertiesUriDetails=""
-        if [ -n "$PROPERTIES_URI_LOCAL_COPY_FOR_HASH" ]; then
-            hashAlg="2.16.840.1.101.3.4.2.1" # SHA256, see https://tools.ietf.org/html/rfc5754 for other common hash algorithm IDs
-            hashValue=$(sha256sum "$PROPERTIES_URI_LOCAL_COPY_FOR_HASH" | sed -r 's/^([0-9a-f]+).*/\1/' | tr -d [:space:] | xxd -r -p | base64 -w 0)
-            hashAlgStr=$(jsonHashAlg "$hashAlg")
-            hashValueStr=$(jsonHashValue "$hashValue")
-            propertiesUriDetails="$hashAlgStr"",""$hashValueStr"
-        fi| sed 's/^[ \t]*//;s/[ \t]*$//'
-    printf "$JSON_PROPERTIESURI_TEMPLATE" "$(toCSV "$propertiesUri" "$propertiesUriDetails")"
+        # variable contains the format string
+        # shellcheck disable=SC2059
+        printf "$JSON_PROPERTIESURI_TEMPLATE" "$(toCSV "$propertiesUri" "$propertiesUriDetails")"
     fi
 }
 jsonIntermediateFile () {
+    # variable contains the format string
+    # shellcheck disable=SC2059
     printf "$JSON_INTERMEDIATE_FILE_OBJECT" "$(toCSV "$@")"
 }

--- a/scripts/nvme.sh
+++ b/scripts/nvme.sh
@@ -3,35 +3,35 @@
 nvmeParse () {
     str=$(nvme list -o json)
     count=$(echo "$str" | jq '.Devices | length')
-    nvmedevices=()
+    nvmeDevices=()
 
     for ((i = 0 ; i < count ; i++ )); do
         elementJson=$(echo "$str" | jq .Devices["$i"])
-        nvmedevices+=("$elementJson")        
+        nvmeDevices+=("$elementJson")        
     done
 }
 nvmeNumDevices () {
-    printf "${#nvmedevices[@]}"
+    printf "${#nvmeDevices[@]}"
 }
 nvmeGetModelNumberForDevice () {
     dev="${1}"
-    str=$(echo "${nvmedevices[$dev]}" | jq -r .ModelNumber)
-    printf "$str"
+    str=$(echo "${nvmeDevices[$dev]}" | jq -r .ModelNumber)
+    printf "%s" "$str"
 }
 nvmeGetSerialNumberForDevice () {
     dev="${1}"
-    str=$(echo "${nvmedevices[$dev]}" | jq -r .SerialNumber)
-    printf "$str"
+    str=$(echo "${nvmeDevices[$dev]}" | jq -r .SerialNumber)
+    printf "%s" "$str"
 }
 nvmeGetEuiForDevice () {
     dev="${1}"
-    devNode=$(echo "${nvmedevices[$dev]}" | jq -r .DevicePath)
+    devNode=$(echo "${nvmeDevices[$dev]}" | jq -r .DevicePath)
     str=$(nvme id-ns "$devNode" -o json | jq -r .eui64)
-    printf "$str"
+    printf "%s" "$str"
 }
 nvmeGetNguidForDevice () {
     dev="${1}"
-    devNode=$(echo "${nvmedevices[$dev]}" | jq -r .DevicePath)
+    devNode=$(echo "${nvmeDevices[$dev]}" | jq -r .DevicePath)
     str=$(nvme id-ns "$devNode" -o json | jq -r .nguid)
-    printf "$str"
+    printf "%s" "$str"
 }

--- a/scripts/smbios.sh
+++ b/scripts/smbios.sh
@@ -2,83 +2,76 @@
 dmidecodeHandles () {
     type="${1}"
     str=$(dmidecode -t "$type" | grep -e '^Handle.*' | sed 's/Handle \(0x[0-9A-F^,]*\),.*/\1/' | tr "\n\r\t" ' ' | sed -e 's/^[[:space:]]*//' | sed -e 's/[[:space:]]*$//')
-    old="$IFS"
-    IFS=' '
-    tableHandles=($str)
-    IFS="$old"
+    local IFS=' '
+    read -r -a tableHandles <<< "$str"
+
+    echo "${tableHandles[*]}"
 }
 dmidecodeData () {
     handle="${1}"
     if  [[ $handle =~ ^0x[0-9A-Fa-f]+$ ]]; then
         str=$(dmidecode -H "$handle" -u | awk '/Header and Data:/{f=1;next} /Strings/{f=0} f' | tr "\n\r\t" ' ' | tr -s ' ' | sed -e 's/^[[:space:]]*//' | sed -e 's/[[:space:]]*$//')
-        old="$IFS"
-        IFS=' '
-        tableData=($str)
-        IFS="$old"
+        local IFS=' '
+        read -r -a tableData <<< "$str"
+
+        echo "${tableData[*]}"
     fi
 }
 dmidecodeStrings () {
     handle="${1}"
     if  [[ $handle =~ ^0x[0-9A-Fa-f]+$ ]]; then
         str=$(dmidecode -H "$handle" -u | awk '/Strings/{f=1;next} /^\w+$/{f=0} f' | sed 's/\t//g' | sed ':a;N;$!ba;s/\n/\t/g' | sed 's/[[:space:]]00[[:space:]]/&"/g' | sed 's/"[^\t]*/&"/g' | sed 's/\t/\n/g' | sed 's/^[^"]*$//g' | sed 's/^\w+//g' | sed 's/""/"/g' | sed '/^[[:space:]]*$/d')
-        old="$IFS"
-        IFS=$'\n'
-        tableStrings=($str)
-        IFS="$old"
+        mapfile -t tableStrings <<< "$str"
+
+        local IFS=$'\n'
+        echo "${tableStrings[*]}"
     fi
 }
-dmidecodeParseHandle () {
-    handle="${1}"
-    dmidecodeData "$handle"
-    dmidecodeStrings "$handle"
-}
 dmidecodeNumHandles () {
-    printf "${#tableHandles[@]}"
-}
-dmidecodeParseTypeAssumeOneHandle () {
-    type="${1}"
-    dmidecodeHandles "$type" > /dev/null
-    dmidecodeParseHandle "${tableHandles[0]}"
+    local tableHandles=("$@")
+    printf "%s" "${#tableHandles[@]}"
 }
 dmidecodeGetByte () {
-    index="${1}"
-    index=$(printf "%d" $index)
-    printf "${tableData[$index]}"
+    local index="${1}"
+    shift
+    local tableData=("$@")
+    index=$(printf "%d" "$index")
+    printf "%s" "${tableData[$index]}"
 }
 dmidecodeGetString () {
-    strref="${1}"
+    local strref="${1}"
+    shift
+    local tableStrings=("$@")
     str=""
     if [[ $strref =~ ^[0-9A-Fa-f]+$ ]]; then
         strrefDec=$(printf "%d" "0x""$strref")
         lenDec=$(printf "%d" "0x"${#tableStrings[@]})
-        if [ $strrefDec -le $lenDec ] && [ $strrefDec -gt 0 ]; then
+        if [ "$strrefDec" -le "$lenDec" ] && [ "$strrefDec" -gt 0 ]; then
             str="${tableStrings[$strrefDec-1]}"
-            str=$(printf "$str" | sed 's/^[ \t]*"\?//;s/"\?[ \t]*$//')
+            str=$(printf "%s" "$str" | sed 's/^[ \t]*"\?//;s/"\?[ \t]*$//')
         fi
     fi
-    printf "$str"
+    printf "%s" "$str"
 }
 
 
 # Examples:
-#dmidecodeHandles "1"
-#numHandles=$(dmidecodeNumHandles)
-#echo $numHandles
-#echo ${tableHandles[*]}
-
-#dmidecodeStrings "${tableHandles[0]}"
-
-#echo ${tableStrings[0]}
-
-#dmidecodeData "${tableHandles[0]}"
-
-#manufacturer=$(dmidecodeGetString $(dmidecodeGetByte "0x4"))
-#model=$(dmidecodeGetByte "0x6")
-#model=$(printf "%d" "0x""$model") # Convert to decimal
-#model=$(dmidecodeGetString $(dmidecodeGetByte "0x5"))
-#serial=$(dmidecodeGetString $(dmidecodeGetByte "0x7"))
-#revision=$(dmidecodeGetString $(dmidecodeGetByte "0x6"))
-#echo $manufacturer
-#echo $model
-#echo $serial
-#echo $revision
+#IFS=' ' read -r -a tableHandles <<< "$(dmidecodeHandles "1")"
+#numHandles=$(dmidecodeNumHandles "${tableHandles[@]}")
+#echo "numHandles: $numHandles"
+#printf "tableHandles: %s\n" "${tableHandles[@]}"
+#
+#IFS=' ' read -r -a tableData <<< "$(dmidecodeData "${tableHandles[0]}")"
+#printf "tableData: %s\n" "${tableData[@]}"
+#
+#mapfile -t tableStrings <<< "$(dmidecodeStrings "${tableHandles[0]}")"
+#printf "tableStrings: %s\n" "${tableStrings[@]}"
+#
+#manufacturer="$(dmidecodeGetString "$(dmidecodeGetByte "0x4" "${tableData[@]}")" "${tableStrings[@]}")"
+#model=$(dmidecodeGetString "$(dmidecodeGetByte "0x5" "${tableData[@]}")" "${tableStrings[@]}")
+#serial=$(dmidecodeGetString "$(dmidecodeGetByte "0x7" "${tableData[@]}")" "${tableStrings[@]}")
+#revision=$(dmidecodeGetString "$(dmidecodeGetByte "0x6" "${tableData[@]}")" "${tableStrings[@]}")
+#printf "manufacturer: %s\n" "$manufacturer"
+#printf "model: %s\n" "$model"
+#printf "serial: %s\n" "$serial"
+#printf "revision: %s\n" "$revision"

--- a/scripts/tcg_ccr.sh
+++ b/scripts/tcg_ccr.sh
@@ -522,6 +522,9 @@ parseGfxData () {
 
 ### Collate the component details
 collectBasicRegistryComponents () {
+    componentChassis=$(parseChassisData)
+	componentBaseboard=$(parseBaseboardData)
+	componentBios=$(parseBiosData)
     componentsCPU=$(parseCpuData)
     componentsRAM=$(parseRamData)
     componentsNIC=$(parseNicData)

--- a/scripts/tcg_ccr.sh
+++ b/scripts/tcg_ccr.sh
@@ -1,0 +1,534 @@
+#!/bin/bash
+
+### User customizable values
+APP_HOME="`dirname "$0"`"
+JSON_SCRIPT="$APP_HOME""/json.sh" # Defines JSON structure and provides methods for producing relevant JSON
+SMBIOS_SCRIPT="$APP_HOME""/smbios.sh"
+HW_SCRIPT="$APP_HOME""/hw.sh" # For some components not covered by SMBIOS
+NVME_SCRIPT="$APP_HOME""/nvme.sh" # For nvme components
+
+### SMBIOS Type Constants
+source $SMBIOS_SCRIPT
+SMBIOS_TYPE_SYSTEM="1"
+SMBIOS_TYPE_PLATFORM="$SMBIOS_TYPE_SYSTEM"
+SMBIOS_TYPE_CHASSIS="3"
+SMBIOS_TYPE_BIOS="0"
+SMBIOS_TYPE_BASEBOARD="2"
+SMBIOS_TYPE_CPU="4"
+SMBIOS_TYPE_RAM="17"
+
+### hw
+source $HW_SCRIPT
+source $NVME_SCRIPT
+
+### ComponentClass values
+COMPCLASS_REGISTRY_TCG="2.23.133.18.3.1" # switch off values within SMBIOS to reveal accurate component classes
+COMPCLASS_BASEBOARD="00030003" # these values are meant to be an example.  check the component class registry.
+COMPCLASS_BIOS="00130003"
+COMPCLASS_UEFI="00130002"
+COMPCLASS_CHASSIS="00020001" # TODO:  chassis type is included in SMBIOS
+COMPCLASS_CPU="00010002"
+COMPCLASS_HDD="00070002"
+COMPCLASS_NIC="00090002"
+COMPCLASS_RAM="00060001"  # TODO: memory type is included in SMBIOS
+COMPCLASS_GFX="00050002"
+
+### JSON
+source $JSON_SCRIPT
+
+## Some of the commands below require root.
+if [ "$EUID" -ne 0 ]
+    then echo "Please run as root"
+    exit
+fi
+
+parseChassisData () {
+    dmidecodeParseTypeAssumeOneHandle "$SMBIOS_TYPE_CHASSIS"
+    chassisClass=$(jsonComponentClass "$COMPCLASS_REGISTRY_TCG" "$COMPCLASS_CHASSIS")
+    chassisManufacturer=$(dmidecodeGetString $(dmidecodeGetByte "0x4"))
+    chassisModel=$(dmidecodeGetByte "0x5")
+    chassisModel=$(printf "%d" "0x""$chassisModel") # Convert to decimal
+    chassisSerial=$(dmidecodeGetString $(dmidecodeGetByte "0x7"))
+    chassisRevision=$(dmidecodeGetString $(dmidecodeGetByte "0x6"))
+
+    if [[ -z "${chassisManufacturer// }" ]]; then
+        chassisManufacturer="$NOT_SPECIFIED"
+    fi
+    chassisManufacturer=$(echo "$chassisManufacturer" | sed 's/^[ \t]*//;s/[ \t]*$//')
+    chassisManufacturer=$(jsonManufacturer "$chassisManufacturer")
+
+    if [[ -z "${chassisModel// }" ]]; then
+        chassisModel="$NOT_SPECIFIED"
+    fi
+    chassisModel=$(echo "$chassisModel" | sed 's/^[ \t]*//;s/[ \t]*$//')
+    chassisModel=$(jsonModel "$chassisModel")
+
+    chassisOptional=""
+    if ! [[ -z "${chassisSerial// }" ]]; then
+        chassisSerial=$(echo "$chassisSerial" | sed 's/^[ \t]*//;s/[ \t]*$//')
+        chassisSerial=$(jsonSerial "$chassisSerial")
+        chassisOptional="$chassisOptional"",""$chassisSerial"
+    fi
+    if ! [[ -z "${chassisRevision// }" ]]; then
+        chassisRevision=$(echo "$chassisRevision" | sed 's/^[ \t]*//;s/[ \t]*$//')
+        chassisRevision=$(jsonRevision "$chassisRevision")
+        chassisOptional="$chassisOptional"",""$chassisRevision"
+    fi
+    chassisOptional=$(printf "$chassisOptional" | cut -c2-)
+    componentChassis=$(jsonComponent "$chassisClass" "$chassisManufacturer" "$chassisModel" "$chassisOptional")
+
+    printf "$componentChassis"
+}
+
+parseBaseboardData () {
+    dmidecodeParseTypeAssumeOneHandle "$SMBIOS_TYPE_BASEBOARD"
+    baseboardClass=$(jsonComponentClass "$COMPCLASS_REGISTRY_TCG" "$COMPCLASS_BASEBOARD")
+    baseboardManufacturer=$(dmidecodeGetString $(dmidecodeGetByte "0x4"))
+    baseboardModel=$(dmidecodeGetString $(dmidecodeGetByte "0x5"))
+    baseboardSerial=$(dmidecodeGetString $(dmidecodeGetByte "0x7"))
+    baseboardRevision=$(dmidecodeGetString $(dmidecodeGetByte "0x6"))
+    baseboardFeatureFlags=$(dmidecodeGetByte "0x9")
+    baseboardFeatureFlags=$(printf "%d" "0x""$baseboardFeatureFlags") # Convert to decimal
+    baseboardReplaceableIndicator="28"
+    baseboardFieldReplaceableAnswer="false"
+    if (((baseboardFeatureFlags&baseboardReplaceableIndicator)!=0)); then
+        baseboardFieldReplaceableAnswer="true"
+    fi
+    baseboardFieldReplaceable=$(jsonFieldReplaceable "$baseboardFieldReplaceableAnswer")
+
+    if [[ -z "${baseboardManufacturer// }" ]]; then
+        baseboardManufacturer="$NOT_SPECIFIED"
+    fi
+    baseboardManufacturer=$(echo "$baseboardManufacturer" | sed 's/^[ \t]*//;s/[ \t]*$//')
+    baseboardManufacturer=$(jsonManufacturer "$baseboardManufacturer")
+
+    if [[ -z "${baseboardModel// }" ]]; then
+        baseboardModel="$NOT_SPECIFIED"
+    fi
+    baseboardModel=$(echo "$baseboardModel" | sed 's/^[ \t]*//;s/[ \t]*$//')
+    baseboardModel=$(jsonModel "$baseboardModel")
+
+    baseboardOptional=""
+    if ! [[ -z "${baseboardSerial// }" ]]; then
+        baseboardSerial=$(echo "$baseboardSerial" | sed 's/^[ \t]*//;s/[ \t]*$//')
+        baseboardSerial=$(jsonSerial "$baseboardSerial")
+        baseboardOptional="$baseboardOptional"",""$baseboardSerial"
+    fi
+    if ! [[ -z "${baseboardRevision// }" ]]; then
+        baseboardRevision=$(echo "$baseboardRevision" | sed 's/^[ \t]*//;s/[ \t]*$//')
+        baseboardRevision=$(jsonRevision "$baseboardRevision")
+        baseboardOptional="$baseboardOptional"",""$baseboardRevision"
+    fi
+    baseboardOptional=$(printf "$baseboardOptional" | cut -c2-)
+    componentBaseboard=$(jsonComponent "$baseboardClass" "$baseboardManufacturer" "$baseboardModel" "$baseboardFieldReplaceable" "$baseboardOptional")
+
+    printf "$componentBaseboard"
+}
+
+parseBiosData () {
+    dmidecodeParseTypeAssumeOneHandle "$SMBIOS_TYPE_BIOS"
+    biosClass=$(jsonComponentClass "$COMPCLASS_REGISTRY_TCG" "$COMPCLASS_BIOS")
+    biosManufacturer=$(dmidecodeGetString $(dmidecodeGetByte "0x4"))
+    biosModel=""
+    biosSerial=""
+    biosRevision=$(dmidecodeGetString $(dmidecodeGetByte "0x5"))
+
+    if [[ -z "${biosManufacturer// }" ]]; then
+        biosManufacturer="$NOT_SPECIFIED"
+    fi
+    biosManufacturer=$(echo "$biosManufacturer" | sed 's/^[ \t]*//;s/[ \t]*$//')
+    biosManufacturer=$(jsonManufacturer "$biosManufacturer")
+
+    if [[ -z "${biosModel// }" ]]; then
+        biosModel="$NOT_SPECIFIED"
+    fi
+    biosModel=$(echo "$biosModel" | sed 's/^[ \t]*//;s/[ \t]*$//')
+    biosModel=$(jsonModel "$biosModel")
+
+    biosOptional=""
+    if ! [[ -z "${biosSerial// }" ]]; then
+        biosSerial=$(echo "$biosSerial" | sed 's/^[ \t]*//;s/[ \t]*$//')
+        biosSerial=$(jsonSerial "$biosSerial")
+        biosOptional="$biosOptional"",""$biosSerial"
+    fi
+    if ! [[ -z "${biosRevision// }" ]]; then
+        biosRevision=$(echo "$biosRevision" | sed 's/^[ \t]*//;s/[ \t]*$//')
+        biosRevision=$(jsonRevision "$biosRevision")
+        biosOptional="$biosOptional"",""$biosRevision"
+    fi
+    biosOptional=$(printf "$biosOptional" | cut -c2-)
+    componentBios=$(jsonComponent "$biosClass" "$biosManufacturer" "$biosModel" "$biosOptional")
+
+    printf "$componentBios"
+}
+
+parseCpuData () {
+    dmidecodeHandles "$SMBIOS_TYPE_CPU"
+
+    notReplaceableIndicator="6"
+    tmpData=""
+    numHandles=$(dmidecodeNumHandles)
+    class=$(jsonComponentClass "$COMPCLASS_REGISTRY_TCG" "$COMPCLASS_CPU")
+
+    for ((i = 0 ; i < numHandles ; i++ )); do
+        dmidecodeParseHandle "${tableHandles[$i]}"
+
+        manufacturer=$(dmidecodeGetString $(dmidecodeGetByte "0x7"))
+        model=$(dmidecodeGetByte "0x6")
+            model=$(printf "%d" "0x""$model") # Convert to decimal
+        serial=$(dmidecodeGetString $(dmidecodeGetByte "0x20"))
+        revision=$(dmidecodeGetString $(dmidecodeGetByte "0x10"))
+            processorUpgrade=$(dmidecodeGetByte "0x19")
+            processorUpgrade=$(printf "%d" "0x""$processorUpgrade") # Convert to decimal
+
+        if [[ -z "${manufacturer// }" ]]; then
+            manufacturer="$NOT_SPECIFIED"
+        fi
+        manufacturer=$(echo "$manufacturer" | sed 's/^[ \t]*//;s/[ \t]*$//')
+        manufacturer=$(jsonManufacturer "$manufacturer")
+
+        if [[ -z "${model// }" ]]; then
+            model="$NOT_SPECIFIED"
+        fi
+        model=$(echo "$model" | sed 's/^[ \t]*//;s/[ \t]*$//')
+        model=$(jsonModel "$model")
+
+        optional=""
+        if ! [[ -z "${serial// }" ]]; then
+            serial=$(echo "$serial" | sed 's/^[ \t]*//;s/[ \t]*$//')
+            serial=$(jsonSerial "$serial")
+            optional="$optional"",""$serial"
+        fi
+        if ! [[ -z "${revision// }" ]]; then
+            revision=$(echo "$revision" | sed 's/^[ \t]*//;s/[ \t]*$//')
+            revision=$(jsonRevision "$revision")
+            optional="$optional"",""$revision"
+        fi
+        optional=$(printf "$optional" | cut -c2-)
+
+        replaceable="true"
+        if [ $processorUpgrade -eq $notReplaceableIndicator ]; then
+            replaceable="false"
+        fi
+        replaceable=$(jsonFieldReplaceable "$replaceable")
+
+        newCpuData=$(jsonComponent "$class" "$manufacturer" "$model" "$replaceable" "$optional")
+        tmpData="$tmpData"",""$newCpuData"
+    done
+
+    # remove leading comma
+    tmpData=$(printf "$tmpData" | cut -c2-)
+
+    printf "$tmpData"
+}
+
+parseRamData () {
+    dmidecodeHandles "$SMBIOS_TYPE_RAM"
+
+    replaceable=$(jsonFieldReplaceable "true")
+    tmpData=""
+    numHandles=$(dmidecodeNumHandles)
+    class=$(jsonComponentClass "$COMPCLASS_REGISTRY_TCG" "$COMPCLASS_RAM")
+
+    for ((i = 0 ; i < numHandles ; i++ )); do
+        dmidecodeParseHandle "${tableHandles[$i]}"
+
+    manufacturer=$(dmidecodeGetString $(dmidecodeGetByte "0x17"))
+    model=$(dmidecodeGetString $(dmidecodeGetByte "0x1A"))
+    serial=$(dmidecodeGetString $(dmidecodeGetByte "0x18"))
+    revision=$(dmidecodeGetString $(dmidecodeGetByte "0x19"))
+
+        if ([[ -z "${manufacturer// }" ]] && [[ -z "${model// }" ]] && [[ -z "${serial// }" ]] && [[ -z "${revision// }" ]]); then
+            continue
+        fi
+
+        if [[ -z "${manufacturer// }" ]]; then
+            manufacturer="$NOT_SPECIFIED"
+        fi
+        manufacturer=$(echo "$manufacturer" | sed 's/^[ \t]*//;s/[ \t]*$//')
+        manufacturer=$(jsonManufacturer "$manufacturer")
+
+        if [[ -z "${model// }" ]]; then
+            model="$NOT_SPECIFIED"
+        fi
+        model=$(echo "$model" | sed 's/^[ \t]*//;s/[ \t]*$//')
+        model=$(jsonModel "$model")
+
+        optional=""
+        if ! [[ -z "${serial// }" ]]; then
+            serial=$(echo "$serial" | sed 's/^[ \t]*//;s/[ \t]*$//')
+            serial=$(jsonSerial "$serial")
+            optional="$optional"",""$serial"
+        fi
+        if ! [[ -z "${revision// }" ]]; then
+            revision=$(echo "$revision" | sed 's/^[ \t]*//;s/[ \t]*$//')
+            revision=$(jsonRevision "$revision")
+            optional="$optional"",""$revision"
+        fi
+        optional=$(printf "$optional" | cut -c2-)
+
+        newRamData=$(jsonComponent "$class" "$manufacturer" "$model" "$replaceable" "$optional")
+        tmpData="$tmpData"",""$newRamData"
+    done
+
+    # remove leading comma
+    tmpData=$(printf "$tmpData" | cut -c2-)
+
+    printf "$tmpData"
+}
+
+# Write script to parse multiple responses
+# Network:
+# lshw description: type of address.
+#                 : Ethernet interface, Wireless interface, Bluetooth wireless interface
+#           vendor: manufacturer
+#          product: model
+#           serial: address & serial number
+#          version: revision
+#
+# Example:
+# ADDRESS1=$(jsonEthernetMac "AB:CD:EE:EE:DE:34")
+# ADDR_LIST=$(jsonAddress "$ADDRESS1" "$ADDRESS2")
+parseNicData () {
+    lshwNetwork
+
+    replaceable=$(jsonFieldReplaceable "true")
+    tmpData=""
+    numHandles=$(lshwNumBusItems)
+    class=$(jsonComponentClass "$COMPCLASS_REGISTRY_TCG" "$COMPCLASS_NIC")
+
+    for ((i = 0 ; i < numHandles ; i++ )); do
+        manufacturer=$(lshwGetVendorIDFromBusItem "$i")
+        model=$(lshwGetProductIDFromBusItem "$i")
+        serialConstant=$(lshwGetLogicalNameFromBusItem "$i")
+        serialConstant=$(ethtoolPermAddr "$serialConstant")
+        serialConstant=$(standardizeMACAddr "${serialConstant}")
+        serial=""
+        revision=$(lshwGetVersionFromBusItem "$i")
+
+        if [[ -z "${manufacturer// }" ]] && [[ -z "${model// }" ]] && (! [[ -z "${serialConstant// }" ]] || ! [[ -z "${revision// }" ]]); then
+            manufacturer=$(lshwGetVendorNameFromBusItem "$i")
+        model=$(lshwGetProductNameFromBusItem "$i")
+        fi
+
+        if [[ -z "${manufacturer// }" ]]; then
+            manufacturer="$NOT_SPECIFIED"
+        fi
+        manufacturer=$(echo "$manufacturer" | sed 's/^[ \t]*//;s/[ \t]*$//')
+        manufacturer=$(jsonManufacturer "$manufacturer")
+
+        if [[ -z "${model// }" ]]; then
+            model="$NOT_SPECIFIED"
+        fi
+        model=$(echo "$model" | sed 's/^[ \t]*//;s/[ \t]*$//')
+        model=$(jsonModel "$model")
+
+        optional=""
+        if ! [[ -z "${serialConstant// }" ]]; then
+            serial=$(echo "$serialConstant" | sed 's/^[ \t]*//;s/[ \t]*$//')
+            serial=$(jsonSerial "$serialConstant")
+            optional="$optional"",""$serial"
+        fi
+        if ! [[ -z "${revision// }" ]]; then
+            revision=$(echo "$revision" | sed 's/^[ \t]*//;s/[ \t]*$//' | awk '{ print toupper($0) }')
+            revision=$(jsonRevision "$revision")
+            optional="$optional"",""$revision"
+        fi
+            bluetoothCap=$(lshwBusItemBluetoothCap "$i")
+            ethernetCap=$(lshwBusItemEthernetCap "$i")
+            wirelessCap=$(lshwBusItemWirelessCap "$i")
+
+            if ([ -n "$bluetoothCap" ] || [ -n "$ethernetCap" ] || [ -n "$wirelessCap" ]) && ! [[ -z "${serialConstant// }" ]]; then
+                thisAddress=
+                if [ -n "$wirelessCap" ]; then
+                    thisAddress=$(jsonWlanMac "$serialConstant")
+                elif [ -n "$bluetoothCap" ]; then
+                    thisAddress=$(jsonBluetoothMac "$serialConstant")
+                elif [ -n "$ethernetCap" ]; then
+                    thisAddress=$(jsonEthernetMac "$serialConstant")
+                fi
+                if [ -n "$thisAddress" ]; then
+                    thisAddress=$(jsonAddress "$thisAddress")
+                    optional="$optional"",""$thisAddress"
+                fi
+            fi
+        optional=$(printf "$optional" | cut -c2-)
+
+        newNicData=$(jsonComponent "$class" "$manufacturer" "$model" "$replaceable" "$optional")
+        tmpData="$tmpData"",""$newNicData"
+    done
+
+    # remove leading comma
+    tmpData=$(printf "$tmpData" | cut -c2-)
+
+    printf "$tmpData"
+}
+
+parseHddData () {
+    lshwDisk
+
+    replaceable=$(jsonFieldReplaceable "true")
+    tmpData=""
+    numHandles=$(lshwNumBusItems)
+    class=$(jsonComponentClass "$COMPCLASS_REGISTRY_TCG" "$COMPCLASS_HDD")
+
+    for ((i = 0 ; i < numHandles ; i++ )); do
+        manufacturer=$(lshwGetVendorIDFromBusItem "$i")
+        model=$(lshwGetProductIDFromBusItem "$i")
+        serial=$(lshwGetSerialFromBusItem "$i")
+        revision=$(lshwGetVersionFromBusItem "$i")
+
+        if [[ -z "${manufacturer// }" ]] && [[ -z "${model// }" ]] && (! [[ -z "${serial// }" ]] || ! [[ -z "${revision// }" ]]); then
+            model=$(lshwGetProductNameFromBusItem "$i")
+            manufacturer=""
+            revision="" # Seeing inconsistent behavior cross-OS for this case, will return
+        fi
+
+        if [[ -z "${manufacturer// }" ]]; then
+            manufacturer="$NOT_SPECIFIED"
+        fi
+        manufacturer=$(echo "$manufacturer" | sed 's/^[ \t]*//;s/[ \t]*$//')
+        manufacturer=$(jsonManufacturer "$manufacturer")
+
+        if [[ -z "${model// }" ]]; then
+            model="$NOT_SPECIFIED"
+        fi
+        model=$(echo "$model" | sed 's/^[ \t]*//;s/[ \t]*$//')
+        model=$(jsonModel "$model")
+
+        optional=""
+        if ! [[ -z "${serial// }" ]]; then
+            serial=$(echo "$serial" | sed 's/^[ \t]*//;s/[ \t]*$//')
+            serial=$(jsonSerial "$serial")
+            optional="$optional"",""$serial"
+        fi
+        if ! [[ -z "${revision// }" ]]; then
+            revision=$(echo "$revision" | sed 's/^[ \t]*//;s/[ \t]*$//' | awk '{ print toupper($0) }')
+            revision=$(jsonRevision "$revision")
+            optional="$optional"",""$revision"
+        fi
+        optional=$(printf "$optional" | cut -c2-)
+
+        newHddData=$(jsonComponent "$class" "$manufacturer" "$model" "$replaceable" "$optional")
+        tmpData="$tmpData"",""$newHddData"
+    done
+
+    # remove leading comma
+    tmpData=$(printf "$tmpData" | cut -c2-)
+
+    printf "$tmpData"
+}
+
+parseNvmeData () {
+    nvmeParse
+
+    replaceable=$(jsonFieldReplaceable "true")
+    tmpData=""
+    numHandles=$(nvmeNumDevices)
+    class=$(jsonComponentClass "$COMPCLASS_REGISTRY_TCG" "$COMPCLASS_HDD")
+
+    for ((i = 0 ; i < numHandles ; i++ )); do
+        manufacturer="" # Making this appear as it does on windows, nvme-cli doesn't return a manufacturer field
+        model=$(nvmeGetModelNumberForDevice "$i")
+        serial=$(nvmeGetNguidForDevice "$i")
+        if [[ $serial =~ ^[0]+$ ]]; then
+            serial=$(nvmeGetEuiForDevice "$i")
+        fi
+        revision="" # empty for a similar reason to the manufacturer field
+
+    if [[ -z "${manufacturer// }" ]]; then
+        manufacturer="$NOT_SPECIFIED"
+    fi
+    manufacturer=$(echo "$manufacturer" | sed 's/^[ \t]*//;s/[ \t]*$//')
+    manufacturer=$(jsonManufacturer "$manufacturer")
+
+    if [[ -z "${model// }" ]]; then
+        model="$NOT_SPECIFIED"
+    fi
+    model=$(echo "${model:0:16}" | sed 's/^[ \t]*//;s/[ \t]*$//') # limited to 16 characters for compatibility to windows, then trimmed
+    model=$(jsonModel "$model")
+
+    optional=""
+    if ! [[ -z "${serial// }" ]]; then
+        serial=$(echo "${serial^^}" | sed 's/^[ \t]*//;s/[ \t]*$//' | sed 's/.\{4\}/&_/g' | sed 's/_$/\./')
+        serial=$(jsonSerial "$serial")
+        optional="$optional"",""$serial"
+    fi
+    optional=$(printf "$optional" | cut -c2-)
+
+        newHddData=$(jsonComponent "$class" "$manufacturer" "$model" "$replaceable" "$optional")
+        tmpData="$tmpData"",""$newHddData"
+    done
+
+    # remove leading comma
+    tmpData=$(printf "$tmpData" | cut -c2-)
+
+    printf "$tmpData"
+}
+
+parseGfxData () {
+    lshwDisplay
+
+    replaceable=$(jsonFieldReplaceable "true")
+    tmpData=""
+    numHandles=$(lshwNumBusItems)
+    class=$(jsonComponentClass "$COMPCLASS_REGISTRY_TCG" "$COMPCLASS_GFX")
+
+    for ((i = 0 ; i < numHandles ; i++ )); do
+        manufacturer=$(lshwGetVendorIDFromBusItem "$i")
+    model=$(lshwGetProductIDFromBusItem "$i")
+    serial=$(lshwGetSerialFromBusItem "$i")
+    revision=$(lshwGetVersionFromBusItem "$i")
+
+        if [[ -z "${manufacturer// }" ]] && [[ -z "${model// }" ]] && (! [[ -z "${serial// }" ]] || ! [[ -z "${revision// }" ]]); then
+            manufacturer=$(lshwGetVendorNameFromBusItem "$i")
+            model=$(lshwGetProductNameFromBusItem "$i")
+        fi
+
+    if [[ -z "${manufacturer// }" ]]; then
+        manufacturer="$NOT_SPECIFIED"
+    fi
+    manufacturer=$(echo "$manufacturer" | sed 's/^[ \t]*//;s/[ \t]*$//')
+    manufacturer=$(jsonManufacturer "$manufacturer")
+
+    if [[ -z "${model// }" ]]; then
+        model="$NOT_SPECIFIED"
+    fi
+    model=$(echo "$model" | sed 's/^[ \t]*//;s/[ \t]*$//')
+    model=$(jsonModel "$model")
+
+    optional=""
+    if ! [[ -z "${serial// }" ]]; then
+        serial=$(echo "$serial" | sed 's/^[ \t]*//;s/[ \t]*$//')
+        serial=$(jsonSerial "$serial")
+        optional="$optional"",""$serial"
+    fi
+    if ! [[ -z "${revision// }" ]]; then
+        revision=$(echo "$revision" | sed 's/^[ \t]*//;s/[ \t]*$//' | awk '{ print toupper($0) }')
+        revision=$(jsonRevision "$revision")
+        optional="$optional"",""$revision"
+    fi
+    optional=$(printf "$optional" | cut -c2-)
+
+        newGfxData=$(jsonComponent "$class" "$manufacturer" "$model" "$replaceable" "$optional")
+        tmpData="$tmpData"",""$newGfxData"
+    done
+
+    # remove leading comma
+    tmpData=$(printf "$tmpData" | cut -c2-)
+
+    printf "$tmpData"
+}
+
+### Collate the component details
+collectBasicRegistryComponents () {
+    componentsCPU=$(parseCpuData)
+    componentsRAM=$(parseRamData)
+    componentsNIC=$(parseNicData)
+    componentsHDD=$(parseHddData)
+    componentsNVMe=$(parseNvmeData)
+    componentsGFX=$(parseGfxData)
+    componentList=$(toCSV "$componentChassis" "$componentBaseboard" "$componentBios" "$componentsCPU" "$componentsRAM" "$componentsNIC" "$componentsHDD" "$componentsNVMe" "$componentsGFX")
+
+    printf "$componentList"
+}

--- a/scripts/windows/get_ek.ps1
+++ b/scripts/windows/get_ek.ps1
@@ -25,7 +25,7 @@ param(
                 }
 
                 if ($data -eq $null) {
-                    echo "Found no EK Certificates using the PowerShell TrustedPlatformModule module."
+                    Write-Output "Found no EK Certificates using the PowerShell TrustedPlatformModule module."
                     $data = $null
                 } else {
                     Write-Progress -Activity "EK Certificate Gathered" -CurrentOperation "Converting to Base64" -PercentComplete 75
@@ -37,7 +37,7 @@ param(
                 }
             }
         Else {
-            echo "Not admin"
+            Write-Output "Not admin"
         }
     }
 )

--- a/scripts/windows/json.ps1
+++ b/scripts/windows/json.ps1
@@ -5,8 +5,8 @@ $PEN_ROOT="1.3.6.1.4.1." # OID root for the private enterprise numbers
 
 ### JSON Structure Keywords
 $JSON_COMPONENTS="COMPONENTS"
-$JSON_PROPERTIES="PROPERTIES"
 $JSON_COMPONENTSURI="COMPONENTSURI"
+$JSON_PROPERTIES="PROPERTIES"
 $JSON_PROPERTIESURI="PROPERTIESURI"
 $JSON_PLATFORM="PLATFORM"
 #### JSON Component Keywords
@@ -242,7 +242,7 @@ function jsonPlatformObject () {
     Write-Output ("$JSON_PLATFORM_TEMPLATE" -f "$(toCSV @args)")
 }
 function jsonComponentsUri ([string]$COMPONENTS_URI="", [string]$COMPONENTS_URI_LOCAL_COPY_FOR_HASH="") {
-    if (![string]::IsNullOrEmpty($COMPONENTS_URI)) {
+    if (![string]::IsNullOrEmpty($COMPONENTS_URI) -and ($COMPONENTS_URI.Trim().Length -ne 0)) {
         $componentsUri=$(jsonUri "$COMPONENTS_URI")
         $componentsUriDetails=""
         if (![string]::IsNullOrEmpty($COMPONENTS_URI_LOCAL_COPY_FOR_HASH) -and ($COMPONENTS_URI_LOCAL_COPY_FOR_HASH.Trim().Length -ne 0) -and (Test-Path -Path $COMPONENTS_URI_LOCAL_COPY_FOR_HASH)) {
@@ -256,7 +256,7 @@ function jsonComponentsUri ([string]$COMPONENTS_URI="", [string]$COMPONENTS_URI_
     }
 }
 function jsonPropertiesUri ([string]$PROPERTIES_URI="", [string]$PROPERTIES_URI_LOCAL_COPY_FOR_HASH="") {
-    if (![string]::IsNullOrEmpty($PROPERTIES_URI)) {
+    if (![string]::IsNullOrEmpty($PROPERTIES_URI) -and ($PROPERTIES_URI.Trim().Length -ne 0)) {
         $propertiesUri=$(jsonUri "$PROPERTIES_URI")
         $propertiesUriDetails=""
         if (![string]::IsNullOrEmpty($PROPERTIES_URI_LOCAL_COPY_FOR_HASH) -and ($PROPERTIES_URI_LOCAL_COPY_FOR_HASH.Trim().Length -ne 0) -and (Test-Path -Path $PROPERTIES_URI_LOCAL_COPY_FOR_HASH)) {

--- a/scripts/windows/json.ps1
+++ b/scripts/windows/json.ps1
@@ -6,6 +6,7 @@ $PEN_ROOT="1.3.6.1.4.1." # OID root for the private enterprise numbers
 ### JSON Structure Keywords
 $JSON_COMPONENTS="COMPONENTS"
 $JSON_PROPERTIES="PROPERTIES"
+$JSON_COMPONENTSURI="COMPONENTSURI"
 $JSON_PROPERTIESURI="PROPERTIESURI"
 $JSON_PLATFORM="PLATFORM"
 #### JSON Component Keywords
@@ -136,7 +137,7 @@ function HexToByteArray { # Powershell doesn't have a built in BinToHex function
     }
 }
 function jsonComponentClass () {
-    echo ("$JSON_COMPONENTCLASS_TEMPLATE" -f "$($args[0])","$($args[1])")
+    Write-Output ("$JSON_COMPONENTCLASS_TEMPLATE" -f "$($args[0])","$($args[1])")
 }
 function jsonManufacturer () {
     $manufacturer=("`"$JSON_MANUFACTURER`": `"{0}`"" -f "$($args[0])")
@@ -145,34 +146,34 @@ function jsonManufacturer () {
     #    $tmpManufacturerId=(jsonManufacturerId "$tmpManufacturerId")
     #    $manufacturer="$manufacturer,$tmpManufacturerId"
     #}
-    echo "$manufacturer"
+    Write-Output "$manufacturer"
 }
 function jsonModel () {
-    echo ("`"$JSON_MODEL`": `"{0}`"" -f "$($args[0])")
+    Write-Output ("`"$JSON_MODEL`": `"{0}`"" -f "$($args[0])")
 }
 function jsonSerial () {
-    echo ("`"$JSON_SERIAL`": `"{0}`"" -f "$($args[0])")
+    Write-Output ("`"$JSON_SERIAL`": `"{0}`"" -f "$($args[0])")
 }
 function jsonRevision () {
-    echo ("`"$JSON_REVISION`": `"{0}`"" -f "$($args[0])")
+    Write-Output ("`"$JSON_REVISION`": `"{0}`"" -f "$($args[0])")
 }
 function jsonManufacturerId () {
-    echo ("`"$JSON_MANUFACTURERID`": `"{0}`"" -f "$($args[0])")
+    Write-Output ("`"$JSON_MANUFACTURERID`": `"{0}`"" -f "$($args[0])")
 }
 function jsonFieldReplaceable () {
-    echo ("`"$JSON_FIELDREPLACEABLE`": `"{0}`"" -f "$($args[0])")
+    Write-Output ("`"$JSON_FIELDREPLACEABLE`": `"{0}`"" -f "$($args[0])")
 }
 function jsonEthernetMac () {
-    echo ("$JSON_ETHERNETMAC_TEMPLATE" -f "$($args[0])")
+    Write-Output ("$JSON_ETHERNETMAC_TEMPLATE" -f "$($args[0])")
 }
 function jsonWlanMac () {
-    echo ("$JSON_WLANMAC_TEMPLATE" -f "$($args[0])")
+    Write-Output ("$JSON_WLANMAC_TEMPLATE" -f "$($args[0])")
 }
 function jsonBluetoothMac () {
-    echo ("$JSON_BLUETOOTHMAC_TEMPLATE" -f "$($args[0])")
+    Write-Output ("$JSON_BLUETOOTHMAC_TEMPLATE" -f "$($args[0])")
 }
 function jsonPlatformModel () {
-    echo ("`"$JSON_PLATFORMMODEL`": `"{0}`"" -f "$($args[0])")
+    Write-Output ("`"$JSON_PLATFORMMODEL`": `"{0}`"" -f "$($args[0])")
 }
 function jsonPlatformManufacturerStr () {
     $manufacturer=("`"$JSON_PLATFORMMANUFACTURERSTR`": `"{0}`"" -f "$($args[0])")
@@ -181,16 +182,16 @@ function jsonPlatformManufacturerStr () {
     #    $tmpManufacturerId=(jsonPlatformManufacturerId "$tmpManufacturerId")
     #    $manufacturer="$manufacturer,$tmpManufacturerId"
     #}
-    echo "$manufacturer"
+    Write-Output "$manufacturer"
 }
 function jsonPlatformVersion () {
-    echo ("`"$JSON_PLATFORMVERSION`": `"{0}`"" -f "$($args[0])")
+    Write-Output ("`"$JSON_PLATFORMVERSION`": `"{0}`"" -f "$($args[0])")
 }
 function jsonPlatformSerial () {
-    echo ("`"$JSON_PLATFORMSERIAL`": `"{0}`"" -f "$($args[0])")
+    Write-Output ("`"$JSON_PLATFORMSERIAL`": `"{0}`"" -f "$($args[0])")
 }
 function jsonPlatformManufacturerId () {
-    echo ("`"$JSON_PLATFORMMANUFACTURERID`": `"{0}`"" -f "$($args[0])")
+    Write-Output ("`"$JSON_PLATFORMMANUFACTURERID`": `"{0}`"" -f "$($args[0])")
 }
 function queryForPen () {
     Write-Progress -Id 3 -ParentId 2 -Activity "Searching for PEN..."
@@ -204,85 +205,70 @@ function queryForPen () {
         }
     }
     Write-Progress -Id 3 -ParentId 2 -Activity "Searching for PEN..." -PercentComplete 100
-    echo $result
+    Write-Output $result
 }
 function jsonProperty () {
     if ($args.Length -eq 2) {
-        echo ("$JSON_PROPERTY_TEMPLATE" -f "$($args[0])","$($args[1])")
+        Write-Output ("$JSON_PROPERTY_TEMPLATE" -f "$($args[0])","$($args[1])")
     } elseif ($args.Length -eq 3) {
-        echo ("$JSON_PROPERTY_TEMPLATE_OPT" -f "$($args[0])","$($args[1])","$($args[2])")
+        Write-Output ("$JSON_PROPERTY_TEMPLATE_OPT" -f "$($args[0])","$($args[1])","$($args[2])")
     }
 }
 function jsonUri () {
-    echo ("`"$JSON_URI`": `"{0}`"" -f "$($args[0])")
+    Write-Output ("`"$JSON_URI`": `"{0}`"" -f "$($args[0])")
 }
 function jsonHashAlg () {
-    echo ("`"$JSON_HASHALG`": `"{0}`"" -f "$($args[0])")
+    Write-Output ("`"$JSON_HASHALG`": `"{0}`"" -f "$($args[0])")
 }
 function jsonHashValue () {
-    echo ("`"$JSON_HASHVALUE`": `"{0}`"" -f "$($args[0])")
+    Write-Output ("`"$JSON_HASHVALUE`": `"{0}`"" -f "$($args[0])")
 }
 function toCSV () {
-    if ($args.Length -ne 0) {
-        Write-Progress -Id 3 -ParentId 2 -Activity "CSV..." -PercentComplete 0
-
-        $size = $args[0].Length
-        for ($i=0; $i -lt $size; $i++) {
-            Write-Progress -Id 3 -ParentId 2 -Activity "CSV..." -PercentComplete (($i / $size) * 100)
-
-            $item=($args[0].Get($i))
-
-            if ($item) {
-                $value="$value,$($args[0].Get($i))"
-            }
-        }
-        echo "$value".Trim(" ", ",")
-        Write-Progress -Id 3 -ParentId 2 -Activity "CSV..." -PercentComplete 100
-    }
+    Write-Output ((($args | Where-Object { $_ -and $_.Trim() -ne "" } | ForEach-Object { $_.ToString() }) -join ",") -replace "}\s*,", "},")
 }
 function jsonAddress () {
-    echo ("$JSON_ADDRESSES_TEMPLATE" -f "$(toCSV($args))")
+    Write-Output ("$JSON_ADDRESSES_TEMPLATE" -f "$(toCSV @args)")
 }
 function jsonComponent () {
-    echo ("$JSON_COMPONENT_TEMPLATE" -f "$(toCSV($args))")
+    Write-Output ("$JSON_COMPONENT_TEMPLATE" -f "$(toCSV @args)")
 }
 function jsonComponentArray () {
-    echo ("$JSON_COMPONENT_ARRAY_TEMPLATE" -f "$(toCSV($args))")
+    Write-Output ("$JSON_COMPONENT_ARRAY_TEMPLATE" -f "$(toCSV @args)")
 }
 function jsonPropertyArray () {
-    echo ("$JSON_PROPERTY_ARRAY_TEMPLATE" -f "$(toCSV($args))")
+    Write-Output ("$JSON_PROPERTY_ARRAY_TEMPLATE" -f "$(toCSV @args)")
 }
 function jsonPlatformObject () {
-    echo ("$JSON_PLATFORM_TEMPLATE" -f "$(toCSV($args))")
+    Write-Output ("$JSON_PLATFORM_TEMPLATE" -f "$(toCSV @args)")
 }
-function jsonComponentsUri () {
-    if ($COMPONENTS_URI) {
-        $componentsUri=(jsonUri "$COMPONENTS_URI")
+function jsonComponentsUri ([string]$COMPONENTS_URI="", [string]$COMPONENTS_URI_LOCAL_COPY_FOR_HASH="") {
+    if (![string]::IsNullOrEmpty($COMPONENTS_URI)) {
+        $componentsUri=$(jsonUri "$COMPONENTS_URI")
         $componentsUriDetails=""
-        if ($COMPONENTS_URI_LOCAL_COPY_FOR_HASH) {
+        if (![string]::IsNullOrEmpty($COMPONENTS_URI_LOCAL_COPY_FOR_HASH) -and ($COMPONENTS_URI_LOCAL_COPY_FOR_HASH.Trim().Length -ne 0) -and (Test-Path -Path $COMPONENTS_URI_LOCAL_COPY_FOR_HASH)) {
             $hashAlg="2.16.840.1.101.3.4.2.1" # SHA256, see https://tools.ietf.org/html/rfc5754 for other common hash algorithm IDs
             $hashValue=([System.Convert]::ToBase64String($(HexToByteArray $(Get-FileHash "$COMPONENTS_URI_LOCAL_COPY_FOR_HASH"  -Algorithm SHA256).Hash.Trim())))
-            $hashAlgStr=(jsonHashAlg "$hashAlg")
-            $hashValueStr=(jsonHashValue "$hashValue")
-            $componentsUriDetails="$hashAlgStr"",""$hashValueStr"
+            $hashAlgStr=$(jsonHashAlg "$hashAlg")
+            $hashValueStr=$(jsonHashValue "$hashValue")
+            $componentsUriDetails="$hashAlgStr,$hashValueStr"
         }
-    echo ("$JSON_COMPONENTSURI_TEMPLATE" -f "$(toCSV("$componentsUri","$componentsUriDetails"))")
+        Write-Output ("$JSON_COMPONENTSURI_TEMPLATE" -f "$(toCSV "$componentsUri" "$componentsUriDetails")")
     }
 }
-function jsonPropertiesUri () {
-    if ($PROPERTIES_URI) {
-        $propertiesUri=(jsonUri "$PROPERTIES_URI")
+function jsonPropertiesUri ([string]$PROPERTIES_URI="", [string]$PROPERTIES_URI_LOCAL_COPY_FOR_HASH="") {
+    if (![string]::IsNullOrEmpty($PROPERTIES_URI)) {
+        $propertiesUri=$(jsonUri "$PROPERTIES_URI")
         $propertiesUriDetails=""
-        if ($PROPERTIES_URI_LOCAL_COPY_FOR_HASH) {
+        if (![string]::IsNullOrEmpty($PROPERTIES_URI_LOCAL_COPY_FOR_HASH) -and ($PROPERTIES_URI_LOCAL_COPY_FOR_HASH.Trim().Length -ne 0) -and (Test-Path -Path $PROPERTIES_URI_LOCAL_COPY_FOR_HASH)) {
             $hashAlg="2.16.840.1.101.3.4.2.1" # SHA256, see https://tools.ietf.org/html/rfc5754 for other common hash algorithm IDs
-            $hashValue=([System.Convert]::ToBase64String($(HexToByteArray $(Get-FileHash "$PROPERTIES_URI_LOCAL_COPY_FOR_HASH"  -Algorithm SHA256).Hash.Trim())))
-            $hashAlgStr=(jsonHashAlg "$hashAlg")
-            $hashValueStr=(jsonHashValue "$hashValue")
+            $hashValue=$([System.Convert]::ToBase64String($(HexToByteArray $(Get-FileHash "$PROPERTIES_URI_LOCAL_COPY_FOR_HASH"  -Algorithm SHA256).Hash.Trim())))
+            $hashAlgStr=$(jsonHashAlg "$hashAlg")
+            $hashValueStr=$(jsonHashValue "$hashValue")
             $propertiesUriDetails="$hashAlgStr,$hashValueStr"
         }
-        echo ("$JSON_PROPERTIESURI_TEMPLATE" -f "$(toCSV("$propertiesUri","$propertiesUriDetails"))")
+        Write-Output ("$JSON_PROPERTIESURI_TEMPLATE" -f "$(toCSV "$propertiesUri" "$propertiesUriDetails")")
     }
 }
 function jsonIntermediateFile () {
-    echo ("$JSON_INTERMEDIATE_FILE_OBJECT" -f "$(toCSV($args))")
+    Write-Output ("$JSON_INTERMEDIATE_FILE_OBJECT" -f "$(toCSV @args)")
 }

--- a/scripts/windows/tcg_ccr.ps1
+++ b/scripts/windows/tcg_ccr.ps1
@@ -1,0 +1,689 @@
+param(
+    [switch] $componentsonly,
+    [string]$printoutfile=""
+)
+
+$APP_HOME=(Split-Path -parent $PSCommandPath)
+$JSON_SCRIPT="$APP_HOME/json.ps1" # Defines JSON structure and provides methods for producing relevant JSON
+$SMBIOS_SCRIPT="$APP_HOME/SMBios.ps1"
+$HW_SCRIPT="$APP_HOME/hw.ps1" # For components not covered by SMBIOS
+$NVME_SCRIPT="$APP_HOME/nvme.ps1" # For NVMe components
+
+### Load Raw SMBios Data
+. $SMBIOS_SCRIPT
+$smbios=(Get-SMBiosStructures)
+$SMBIOS_TYPE_SYSTEM="1"
+$SMBIOS_TYPE_PLATFORM="$SMBIOS_TYPE_SYSTEM"
+$SMBIOS_TYPE_CHASSIS="3"
+$SMBIOS_TYPE_BIOS="0"
+$SMBIOS_TYPE_BASEBOARD="2"
+$SMBIOS_TYPE_CPU="4"
+$SMBIOS_TYPE_RAM="17"
+
+### hw
+. $HW_SCRIPT
+### nvme
+. $NVME_SCRIPT
+
+### ComponentClass values
+$COMPCLASS_REGISTRY_TCG="2.23.133.18.3.1" # Could lookup values within SMBIOS to reveal accurate component classes.
+$COMPCLASS_BASEBOARD="00030003" # these values are meant to be an example.  check the TCG component class registry.
+$COMPCLASS_BIOS="00130003"
+#$COMPCLASS_UEFI="00130002" # available as an example. uncomment to utilize.
+$COMPCLASS_CHASSIS="00020001"
+$COMPCLASS_CPU="00010002"
+$COMPCLASS_HDD="00070002"
+$COMPCLASS_NIC="00090002"
+$COMPCLASS_RAM="00060001"
+$COMPCLASS_GFX="00050002"
+
+### JSON
+. $JSON_SCRIPT
+
+## Some of the commands below require admin.
+If(!(New-Object Security.Principal.WindowsPrincipal(
+        [Security.Principal.WindowsIdentity]::GetCurrent())).IsInRole(
+            [Security.Principal.WindowsBuiltInRole]::Administrator)) {
+	Write-Output "Please run as admin"
+	exit
+}
+
+function parseSystemData() {
+	Write-Progress -Id 2 -ParentId 1 -Activity "Gathering platform information" -CurrentOperation "Collecting data from SMBIOS" -PercentComplete 0
+	### Gather platform details for the subject alternative name
+	Write-Progress -Id 3 -ParentId 2 -Activity "Collecting system data" -CurrentOperation "Collecting manufacturer" -PercentComplete 0
+	$platformManufacturer=(Get-SMBiosString $smbios "$SMBIOS_TYPE_PLATFORM" 0x4)
+	Write-Progress -Id 3 -ParentId 2 -Activity "Collecting system data" -CurrentOperation "Collecting model" -PercentComplete 25
+	$platformModel=(Get-SMBiosString $smbios "$SMBIOS_TYPE_PLATFORM" 0x5)
+	Write-Progress -Id 3 -ParentId 2 -Activity "Collecting system data" -CurrentOperation "Collecting version" -PercentComplete 50
+	$platformVersion=(Get-SMBiosString $smbios "$SMBIOS_TYPE_PLATFORM" 0x6)
+	Write-Progress -Id 3 -ParentId 2 -Activity "Collecting system data" -CurrentOperation "Collecting serial number" -PercentComplete 75
+	$platformSerial=(Get-SMBiosString $smbios "$SMBIOS_TYPE_PLATFORM" 0x7)
+	Write-Progress -Id 3 -ParentId 2 -Activity "Collecting system data" -CurrentOperation "Done" -Completed
+
+	Write-Progress -Id 2 -ParentId 1 -Activity "Gathering platform information" -CurrentOperation "Cleaning output" -PercentComplete 40
+	if ([string]::IsNullOrEmpty($platformManufacturer) -or ($platformManufacturer.Trim().Length -eq 0)) {
+		$platformManufacturer="$NOT_SPECIFIED"
+	}
+	$platformManufacturer=$(jsonPlatformManufacturerStr "$platformManufacturer".Trim())
+
+	Write-Progress -Id 2 -ParentId 1 -Activity "Gathering platform information" -CurrentOperation "Cleaning output" -PercentComplete 55
+	if ([string]::IsNullOrEmpty($platformModel) -or ($platformModel.Trim().Length -eq 0)) {
+		$platformModel="$NOT_SPECIFIED"
+	}
+	$platformModel=$(jsonPlatformModel "$platformModel".Trim())
+
+	Write-Progress -Id 2 -ParentId 1 -Activity "Gathering platform information" -CurrentOperation "Cleaning output" -PercentComplete 70
+	if ([string]::IsNullOrEmpty($platformVersion) -or ($platformVersion.Trim().Length -eq 0)) {
+		$platformVersion="$NOT_SPECIFIED"
+	}
+	$platformVersion=$(jsonPlatformVersion "$platformVersion".Trim())
+
+	Write-Progress -Id 2 -ParentId 1 -Activity "Gathering platform information" -CurrentOperation "Cleaning output" -PercentComplete 85
+	if (![string]::IsNullOrEmpty($platformSerial) -and ($platformSerial.Trim().Length -ne 0)) {
+		$platformSerial=$(jsonPlatformSerial "$platformSerial".Trim())
+	}
+	$platform=$(toCSV "$platformManufacturer" "$platformModel" "$platformVersion" "$platformSerial")
+	Write-Progress -Id 2 -ParentId 1 -Activity "Gathering platform information" -CurrentOperation "Done" -Completed
+	return "$platform"
+}
+
+function parseChassisData() {
+	Write-Progress -Id 2 -ParentId 1 -Activity "Gathering chassis information" -CurrentOperation "Collecting data from SMBIOS" -PercentComplete 0
+	Write-Progress -Id 3 -ParentId 2 -Activity "Collecting chassis data" -CurrentOperation "Collecting manufacturer" -PercentComplete 0
+	$chassisManufacturer=$(Get-SMBiosString $smbios "$SMBIOS_TYPE_CHASSIS" 0x4)
+	Write-Progress -Id 3 -ParentId 2 -Activity "Collecting chassis data" -CurrentOperation "Collecting model" -PercentComplete 25
+	$chassisModel=[string]($smbios["$SMBIOS_TYPE_CHASSIS"].data[0x5])
+	Write-Progress -Id 3 -ParentId 2 -Activity "Collecting chassis data" -CurrentOperation "Collecting serial" -PercentComplete 50
+	$chassisSerial=$(Get-SMBiosString $smbios "$SMBIOS_TYPE_CHASSIS" 0x7)
+	Write-Progress -Id 3 -ParentId 2 -Activity "Collecting chassis data" -CurrentOperation "Collecting revision" -PercentComplete 75
+	$chassisRevision=$(Get-SMBiosString $smbios "$SMBIOS_TYPE_CHASSIS" 0x6)
+	Write-Progress -Id 3 -ParentId 2 -Activity "Collecting chassis data" -CurrentOperation "Done" -Completed
+
+	Write-Progress -Id 2 -ParentId 1 -Activity "Gathering chassis information" -CurrentOperation "Cleaning output" -PercentComplete 30
+	$chassisClass=$(jsonComponentClass "$COMPCLASS_REGISTRY_TCG" "$COMPCLASS_CHASSIS")
+
+	Write-Progress -Id 2 -ParentId 1 -Activity "Gathering chassis information" -CurrentOperation "Cleaning output" -PercentComplete 40
+	if ([string]::IsNullOrEmpty($chassisManufacturer) -or ($chassisManufacturer.Trim().Length -eq 0)) {
+		$chassisManufacturer="$NOT_SPECIFIED"
+	}
+	$chassisManufacturer=$(jsonManufacturer "$chassisManufacturer".Trim())
+
+	Write-Progress -Id 2 -ParentId 1 -Activity "Gathering chassis information" -CurrentOperation "Cleaning output" -PercentComplete 55
+	if ([string]::IsNullOrEmpty($chassisModel) -or ($chassisModel.Trim().Length -eq 0)) {
+		$chassisModel="$NOT_SPECIFIED"
+	}
+	$chassisModel=$(jsonModel "$chassisModel".Trim())
+
+	Write-Progress -Id 2 -ParentId 1 -Activity "Gathering chassis information" -CurrentOperation "Cleaning output" -PercentComplete 70
+	if (![string]::IsNullOrEmpty($chassisSerial) -and ($chassisSerial.Trim().Length -ne 0)) {
+		$chassisSerial=$(jsonSerial "$chassisSerial".Trim())
+	}
+
+	Write-Progress -Id 2 -ParentId 1 -Activity "Gathering chassis information" -CurrentOperation "Cleaning output" -PercentComplete 85
+	if (![string]::IsNullOrEmpty($chassisRevision) -and ($chassisRevision.Trim().Length -ne 0)) {
+		$chassisRevision=$(jsonRevision "$chassisRevision".Trim())
+	}
+	$componentChassis=$(jsonComponent "$chassisClass" "$chassisManufacturer" "$chassisModel" "$chassisSerial" "$chassisRevision")
+	Write-Progress -Id 2 -ParentId 1 -Activity "Gathering chassis information" -CurrentOperation "Done" -Completed
+	
+	return "$componentChassis"
+}
+
+function parseBaseboardData() {
+	Write-Progress -Id 2 -ParentId 1 -Activity "Gathering baseboard information" -CurrentOperation "Collecting data from SMBIOS" -PercentComplete 0
+	Write-Progress -Id 3 -ParentId 2 -Activity "Collecting baseboard data" -CurrentOperation "Collecting manufacturer" -PercentComplete 0
+	$baseboardManufacturer=$(Get-SMBiosString $smbios "$SMBIOS_TYPE_BASEBOARD" 0x4)
+	Write-Progress -Id 3 -ParentId 2 -Activity "Collecting baseboard data" -CurrentOperation "Collecting model" -PercentComplete 20
+	$baseboardModel=$(Get-SMBiosString $smbios "$SMBIOS_TYPE_BASEBOARD" 0x5)
+	Write-Progress -Id 3 -ParentId 2 -Activity "Collecting baseboard data" -CurrentOperation "Collecting serial" -PercentComplete 40
+	$baseboardSerial=$(Get-SMBiosString $smbios "$SMBIOS_TYPE_BASEBOARD" 0x7)
+	Write-Progress -Id 3 -ParentId 2 -Activity "Collecting baseboard data" -CurrentOperation "Collecting revision" -PercentComplete 60
+	$baseboardRevision=$(Get-SMBiosString $smbios "$SMBIOS_TYPE_BASEBOARD" 0x6)
+	Write-Progress -Id 3 -ParentId 2 -Activity "Collecting baseboard data" -CurrentOperation "Collecting replaceable indicator" -PercentComplete 80
+	$baseboardFeatureFlags=$smbios["$SMBIOS_TYPE_BASEBOARD"].data[0x9]
+	$baseboardReplaceableIndicator=0x1C # from Table 14
+	Write-Progress -Id 3 -ParentId 2 -Activity "Collecting baseboard data" -CurrentOperation "Done" -Completed
+	
+	Write-Progress -Id 2 -ParentId 1 -Activity "Gathering baseboard information" -CurrentOperation "Cleaning output" -PercentComplete 30
+	$baseboardClass=$(jsonComponentClass "$COMPCLASS_REGISTRY_TCG" "$COMPCLASS_BASEBOARD")
+
+	Write-Progress -Id 2 -ParentId 1 -Activity "Gathering baseboard information" -CurrentOperation "Cleaning output" -PercentComplete 40
+	$baseboardFieldReplaceableAnswer="false"
+	if ("$baseboardFeatureFlags" -band "$baseboardReplaceableIndicator") {
+		$baseboardFieldReplaceableAnswer="true"
+	}
+	$baseboardFieldReplaceable=$(jsonFieldReplaceable "$baseboardFieldReplaceableAnswer")
+
+	Write-Progress -Id 2 -ParentId 1 -Activity "Gathering baseboard information" -CurrentOperation "Cleaning output" -PercentComplete 52
+	if ([string]::IsNullOrEmpty($baseboardManufacturer) -or ($baseboardManufacturer.Trim().Length -eq 0)) {
+		$baseboardManufacturer="$NOT_SPECIFIED"
+	}
+	$baseboardManufacturer=$(jsonManufacturer "$baseboardManufacturer".Trim())
+
+	Write-Progress -Id 2 -ParentId 1 -Activity "Gathering baseboard information" -CurrentOperation "Cleaning output" -PercentComplete 64
+	if ([string]::IsNullOrEmpty($baseboardModel) -or ($baseboardModel.Trim().Length -eq 0)) {
+		$baseboardModel="$NOT_SPECIFIED"
+	}
+	$baseboardModel=$(jsonModel "$baseboardModel".Trim())
+
+	Write-Progress -Id 2 -ParentId 1 -Activity "Gathering baseboard information" -CurrentOperation "Cleaning output" -PercentComplete 76
+	if (![string]::IsNullOrEmpty($baseboardSerial) -and ($baseboardSerial.Trim().Length -ne 0)) {
+		$baseboardSerial=$(jsonSerial "$baseboardSerial".Trim())
+	}
+
+	Write-Progress -Id 2 -ParentId 1 -Activity "Gathering baseboard information" -CurrentOperation "Cleaning output" -PercentComplete 88
+	if (![string]::IsNullOrEmpty($baseboardRevision) -and ($baseboardRevision.Trim().Length -ne 0)) {
+		$baseboardRevision=$(jsonRevision "$baseboardRevision".Trim())
+	}
+	$componentBaseboard=$(jsonComponent "$baseboardClass" "$baseboardManufacturer" "$baseboardModel" "$baseboardFieldReplaceable" "$baseboardSerial" "$baseboardRevision")
+
+	Write-Progress -Id 2 -ParentId 1 -Activity "Gathering baseboard information" -CurrentOperation "Done" -Completed
+	
+	return "$componentBaseboard"
+}
+
+function parseBiosData() {
+	Write-Progress -Id 2 -ParentId 1 -Activity "Gathering BIOS information" -CurrentOperation "Collecting data from SMBIOS" -PercentComplete 0
+	Write-Progress -Id 3 -ParentId 2 -Activity "Collecting BIOS data" -CurrentOperation "Collecting manufacturer" -PercentComplete 0
+	$biosManufacturer=$(Get-SMBiosString $smbios "$SMBIOS_TYPE_BIOS" 0x4)
+	$biosModel=""
+	$biosSerial=""
+	Write-Progress -Id 3 -ParentId 2 -Activity "Collecting BIOS data" -CurrentOperation "Collecting revision" -PercentComplete 75
+	$biosRevision=(Get-SMBiosString $smbios "$SMBIOS_TYPE_BIOS" 0x5)
+	Write-Progress -Id 3 -ParentId 2 -Activity "Collecting BIOS data" -CurrentOperation "Done" -Completed
+	
+	Write-Progress -Id 2 -ParentId 1 -Activity "Gathering BIOS information" -CurrentOperation "Cleaning output" -PercentComplete 30
+	$biosClass=$(jsonComponentClass "$COMPCLASS_REGISTRY_TCG" "$COMPCLASS_BIOS")
+
+	Write-Progress -Id 2 -ParentId 1 -Activity "Gathering BIOS information" -CurrentOperation "Cleaning output" -PercentComplete 40
+	if ([string]::IsNullOrEmpty($biosManufacturer) -or ($biosManufacturer.Trim().Length -eq 0)) {
+		$biosManufacturer="$NOT_SPECIFIED"
+	}
+	$biosManufacturer=$(jsonManufacturer "$biosManufacturer".Trim())
+
+	Write-Progress -Id 2 -ParentId 1 -Activity "Gathering BIOS information" -CurrentOperation "Cleaning output" -PercentComplete 55
+	if ([string]::IsNullOrEmpty($biosModel) -or ($biosModel.Trim().Length -eq 0)) {
+		$biosModel="$NOT_SPECIFIED"
+	}
+	$biosModel=$(jsonModel "$biosModel".Trim())
+
+	Write-Progress -Id 2 -ParentId 1 -Activity "Gathering BIOS information" -CurrentOperation "Cleaning output" -PercentComplete 70
+	if (![string]::IsNullOrEmpty($biosSerial) -and ($biosSerial.Trim().Length -ne 0)) {
+		$biosSerial=$(jsonSerial "$biosSerial".Trim())
+	}
+
+	Write-Progress -Id 2 -ParentId 1 -Activity "Gathering BIOS information" -CurrentOperation "Cleaning output" -PercentComplete 85
+	if (![string]::IsNullOrEmpty($biosRevision) -and ($biosRevision.Trim().Length -ne 0)) {
+		$biosRevision=$(jsonRevision "$biosRevision".Trim())
+	}
+	$componentBios=$(jsonComponent "$biosClass" "$biosManufacturer" "$biosModel" "$biosSerial" "$biosRevision")
+
+	Write-Progress -Id 2 -ParentId 1 -Activity "Gathering baseboard information" -CurrentOperation "Done" -Completed
+	
+	return "$componentBios"
+}
+
+function parseCpuData() {
+	Write-Progress -Id 2 -ParentId 1 -Activity "Gathering CPU information" -CurrentOperation "Collecting data from SMBIOS" -PercentComplete 0
+    $RS=@($smbios["$SMBIOS_TYPE_CPU"])
+    $component=""
+    $numRows=$RS.Count
+    $processorNotUpgradableIndicator=0x6
+
+    for($i=0;$i -lt $numRows;$i++) {
+        Write-Progress -Id 2 -ParentId 1 -Activity "Gathering CPU information" -CurrentOperation ("Parsing data from SMBIOS for CPU " + ($i+1)) -PercentComplete ((($i+1) / $numRows) * 100)
+
+        Write-Progress -Id 3 -ParentId 2 -Activity "Collecting CPU data" -CurrentOperation "Collecting manufacturer" -PercentComplete 0
+        $tmpManufacturer=$(Get-SMBiosString $RS $i 0x7)
+		Write-Progress -Id 3 -ParentId 2 -Activity "Collecting CPU data" -CurrentOperation "Collecting model" -PercentComplete 20
+        $tmpModel=[string]($RS[$i].data[0x6]) # Enum value for Family
+		Write-Progress -Id 3 -ParentId 2 -Activity "Collecting CPU data" -CurrentOperation "Collecting serial" -PercentComplete 40
+        $tmpSerial=$(Get-SMBiosString $RS $i 0x20)
+		Write-Progress -Id 3 -ParentId 2 -Activity "Collecting CPU data" -CurrentOperation "Collecting revision" -PercentComplete 60
+        $tmpRevision=$(Get-SMBiosString $RS $i 0x10)
+		Write-Progress -Id 3 -ParentId 2 -Activity "Collecting CPU data" -CurrentOperation "Collecting replaceable indicator" -PercentComplete 80
+        $tmpUpgradeMethod=$RS[$i].data[0x19] # Enum for Processor Upgrade
+		
+		Write-Progress -Id 3 -ParentId 2 -Activity "Gathering CPU information" -CurrentOperation "Cleaning output" -PercentComplete 90
+		$cpuClass=$(jsonComponentClass "$COMPCLASS_REGISTRY_TCG" "$COMPCLASS_CPU")
+
+        if ([string]::IsNullOrEmpty($tmpManufacturer) -or ($tmpManufacturer.Trim().Length -eq 0)) {
+            $tmpManufacturer="$NOT_SPECIFIED"
+        }
+        $tmpManufacturer=$(jsonManufacturer "$tmpManufacturer".Trim())
+
+        if ([string]::IsNullOrEmpty($tmpModel) -or ($tmpModel.Trim().Length -eq 0)) {
+            $tmpModel="$NOT_SPECIFIED"
+        }
+        $tmpModel=$(jsonModel "$tmpModel".Trim())
+
+        if (![string]::IsNullOrEmpty($tmpSerial) -and ($tmpSerial.Trim().Length -ne 0)) {
+            $tmpSerial=$(jsonSerial "$tmpSerial".Trim())
+        } else {
+            $tmpSerial=""
+        }
+
+        if (![string]::IsNullOrEmpty($tmpRevision) -and ($tmpRevision.Trim().Length -ne 0)) {
+            $tmpRevision=$(jsonRevision "$tmpRevision".Trim())
+        } else {
+            $tmpRevision=""
+        }
+
+        if ("$tmpUpgradeMethod" -eq "$processorNotUpgradableIndicator") {
+            $tmpUpgradeMethod="false"
+        } else {
+            $tmpUpgradeMethod="true"
+        }
+        $replaceable=$(jsonFieldReplaceable "$tmpUpgradeMethod")
+
+        $tmpComponent=$(jsonComponent $cpuClass $tmpManufacturer $tmpModel $replaceable $tmpSerial $tmpRevision)
+        $component+="$tmpComponent,"
+		Write-Progress -Id 3 -ParentId 2 -Activity "Gathering CPU information" -CurrentOperation "Cleaning output" -Completed
+    }
+    Write-Progress -Id 2 -ParentId 1 -Activity "Gathering CPU information" -CurrentOperation "Done" -Completed
+    return "$component".Trim(",")
+}
+
+function parseRamData() {
+	Write-Progress -Id 2 -ParentId 1 -Activity "Gathering RAM information" -CurrentOperation "Collecting data from SMBIOS" -PercentComplete 0
+    $RS=@($smbios["$SMBIOS_TYPE_RAM"])
+    $component=""
+    $replaceable=$(jsonFieldReplaceable "true") # Looking for reliable indicator
+    $numRows=$RS.Count
+	
+	$ramClass=$(jsonComponentClass "$COMPCLASS_REGISTRY_TCG" "$COMPCLASS_RAM")
+
+    for($i=0;$i -lt $numRows;$i++) {
+        Write-Progress -Id 2 -ParentId 1 -Activity "Gathering RAM information" -CurrentOperation ("Parsing data from SMBIOS for Memory Chip " + ($i+1)) -PercentComplete ((($i+1) / $numRows) * 100)
+
+        Write-Progress -Id 3 -ParentId 2 -Activity "Collecting RAM data" -CurrentOperation "Collecting manufacturer" -PercentComplete 0
+        $tmpManufacturer=(Get-SMBiosString $RS $i 0x17)
+		Write-Progress -Id 3 -ParentId 2 -Activity "Collecting RAM data" -CurrentOperation "Collecting model" -PercentComplete 20
+        $tmpModel=(Get-SMBiosString $RS $i 0x1A)
+		Write-Progress -Id 3 -ParentId 2 -Activity "Collecting RAM data" -CurrentOperation "Collecting serial" -PercentComplete 40
+        $tmpSerial=(Get-SMBiosString $RS $i 0x18)
+		Write-Progress -Id 3 -ParentId 2 -Activity "Collecting RAM data" -CurrentOperation "Collecting revision" -PercentComplete 60
+        $tmpRevision=(Get-SMBiosString $RS $i 0x19)
+		
+		Write-Progress -Id 3 -ParentId 2 -Activity "Gathering RAM information" -CurrentOperation "Cleaning output" -PercentComplete 90
+
+        if ([string]::IsNullOrEmpty($tmpManufacturer) -and [string]::IsNullOrEmpty($tmpModel) -and [string]::IsNullOrEmpty($tmpSerial) -and [string]::IsNullOrEmpty($tmpRevision)) {
+            Continue;
+        }
+
+        if ([string]::IsNullOrEmpty($tmpManufacturer) -or ($tmpManufacturer.Trim().Length -eq 0)) {
+            $tmpManufacturer="$NOT_SPECIFIED"
+        }
+        $tmpManufacturer=$(jsonManufacturer "$tmpManufacturer".Trim())
+
+        if ([string]::IsNullOrEmpty($tmpModel) -or ($tmpModel.Trim().Length -eq 0)) {
+            $tmpModel="$NOT_SPECIFIED"
+        }
+        $tmpModel=$(jsonModel "$tmpModel".Trim())
+
+        if (![string]::IsNullOrEmpty($tmpSerial) -and ($tmpSerial.Trim().Length -ne 0)) {
+            $tmpSerial=$(jsonSerial "$tmpSerial".Trim())
+        } else {
+            $tmpSerial=""
+        }
+
+        if (![string]::IsNullOrEmpty($tmpRevision) -and ($tmpRevision.Trim().Length -ne 0)) {
+            $tmpRevision=$(jsonRevision "$tmpRevision".Trim())
+        } else {
+            $tmpRevision=""
+        }
+        $tmpComponent=$(jsonComponent $ramClass $tmpManufacturer $tmpModel $replaceable $tmpSerial $tmpRevision)
+        $component+="$tmpComponent,"
+		Write-Progress -Id 3 -ParentId 2 -Activity "Gathering RAM information" -CurrentOperation "Cleaning output" -Completed
+    }
+
+    Write-Progress -Id 2 -ParentId 1 -Activity "Gathering RAM information" -CurrentOperation "Done" -Completed
+    return "$component".Trim(",")
+}
+
+function parseNicData() {
+	Write-Progress -Id 2 -ParentId 1 -Activity "Gathering NIC information" -CurrentOperation "Collecting data from Powershell" -PercentComplete 0
+    $RS=(Get-NetAdapter | Select-Object MacAddress,PhysicalMediaType,PNPDeviceID | Where-Object {($_.PhysicalMediaType -eq "Native 802.11" -or "802.3") -and ($_.PNPDeviceID -Match "^(PCI)\\.*$")})
+    $component=""
+    $replaceable=$(jsonFieldReplaceable "true")
+    $numRows=$RS.Count
+	
+	$nicClass=$(jsonComponentClass "$COMPCLASS_REGISTRY_TCG" "$COMPCLASS_NIC")
+
+    for($i=0;$i -lt $numRows;$i++) {
+        Write-Progress -Id 2 -ParentId 1 -Activity "Gathering NIC information" -CurrentOperation ("Parsing data from Powershell for NIC " + ($i+1)) -PercentComplete ((($i+1) / $numRows) * 100)
+
+        $pnpDevID=""
+        if(isPCI($RS[$i].PNPDeviceID)) {
+            $pnpDevID=$(pciParse $RS[$i].PNPDeviceID)
+        } else {
+            Continue
+        }
+
+		Write-Progress -Id 3 -ParentId 2 -Activity "Collecting NIC data" -CurrentOperation "Collecting manufacturer" -PercentComplete 0
+        $tmpManufacturer=$pnpDevID.vendor # PCI Vendor ID
+		Write-Progress -Id 3 -ParentId 2 -Activity "Collecting NIC data" -CurrentOperation "Collecting model" -PercentComplete 20
+        $tmpModel=$pnpDevID.product  # PCI Device Hardware ID
+		Write-Progress -Id 3 -ParentId 2 -Activity "Collecting NIC data" -CurrentOperation "Collecting serial and MAC" -PercentComplete 40
+        $tmpSerialConstant=($RS[$i].MacAddress)
+        $tmpSerialConstant=$(standardizeMACAddr $tmpSerialConstant)
+        $tmpSerial=""
+		Write-Progress -Id 3 -ParentId 2 -Activity "Collecting NIC data" -CurrentOperation "Collecting revision" -PercentComplete 60
+        $tmpRevision=$pnpDevID.revision
+		Write-Progress -Id 3 -ParentId 2 -Activity "Gathering NIC information" -CurrentOperation "Collecting NIC type" -PercentComplete 80
+        $tmpMediaType=$RS[$i].PhysicalMediaType
+        $thisAddress=""
+		
+		Write-Progress -Id 3 -ParentId 2 -Activity "Gathering RAM information" -CurrentOperation "Cleaning output" -PercentComplete 90
+		
+        if ([string]::IsNullOrEmpty($tmpManufacturer) -or ($tmpManufacturer.Trim().Length -eq 0)) {
+            $tmpManufacturer="$NOT_SPECIFIED"
+        }
+        $tmpManufacturer=$(jsonManufacturer "$tmpManufacturer".Trim())
+
+
+        if ([string]::IsNullOrEmpty($tmpModel) -or ($tmpModel.Trim().Length -eq 0)) {
+            $tmpModel="$NOT_SPECIFIED"
+        }
+        $tmpModel=$(jsonModel "$tmpModel".Trim())
+
+
+
+        if (![string]::IsNullOrEmpty($tmpSerialConstant) -and ($tmpSerialConstant.Trim().Length -ne 0)) {
+            $tmpSerial=$(jsonSerial "$tmpSerialConstant".Trim())
+        } else {
+            $tmpSerial=""
+        }
+
+
+        if (![string]::IsNullOrEmpty($tmpRevision) -and ($tmpRevision.Trim().Length -ne 0)) {
+            $tmpRevision=$(jsonRevision "$tmpRevision".Trim())
+        } else {
+            $tmpRevision=""
+        }
+
+        if ($tmpMediaType -and $tmpSerial) {
+            if ("$tmpMediaType" -match "^.*802[.]11.*$") {
+                $thisAddress=$(jsonWlanMac $tmpSerialConstant)
+            }
+            elseif ("$tmpMediaType" -match "^.*[Bb]lue[Tt]ooth.*$") {
+                $thisAddress=$(jsonBluetoothMac $tmpSerialConstant)
+            }
+            elseif ("$tmpMediaType" -match "^.*802[.]3.*$") {
+                $thisAddress=$(jsonEthernetMac $tmpSerialConstant)
+            }
+            if ($thisAddress) {
+                $thisAddress=$(jsonAddress "$thisAddress")
+            }
+        }
+
+        $tmpComponent=$(jsonComponent $nicClass $tmpManufacturer $tmpModel $replaceable $tmpSerial $tmpRevision $thisAddress)
+        $component+="$tmpComponent,"
+		Write-Progress -Id 3 -ParentId 2 -Activity "Gathering NIC information" -CurrentOperation "Cleaning output" -Completed
+    }
+
+    Write-Progress -Id 2 -ParentId 1 -Activity "Gathering NIC information" -CurrentOperation "Done" -Completed
+    return "$component".Trim(",")
+}
+
+function parseHddData() {
+	Write-Progress -Id 2 -ParentId 1 -Activity "Gathering Hard Disk information" -CurrentOperation "Collecting data from Powershell" -PercentComplete 0
+    #$RS=(Get-CimInstance -ClassName CIM_DiskDrive | select serialnumber,mediatype,pnpdeviceid,manufacturer,model | where mediatype -eq "Fixed hard disk media")
+    $RS=(Get-PhysicalDisk | Select-Object serialnumber,mediatype,manufacturer,model,bustype | Where-Object BusType -ne NVMe)
+    $component=""
+    $replaceable=$(jsonFieldReplaceable "true")
+    $numRows=0
+    if ($null -ne $RS) { # powershell $null should be left operand
+		if ($RS -is [array]) {
+			$numRows=($RS.Count)
+		} else {
+			$numRows=1
+        }
+    }
+	
+	$hddClass=$(jsonComponentClass "$COMPCLASS_REGISTRY_TCG" "$COMPCLASS_HDD")
+	
+    for($i=0;$i -lt $numRows;$i++) {
+        Write-Progress -Id 2 -ParentId 1 -Activity "Gathering Hard Disk information" -CurrentOperation ("Parsing data from Powershell for HDD " + ($i+1)) -PercentComplete ((($i+1) / $numRows) * 100)
+		
+        #$pnpDevID=""
+        #if(isIDE($RS[$i].PNPDeviceID)) {
+        #   $pnpDevID=(ideDiskParse $RS[$i].PNPDeviceID)
+        #} elseif(isSCSI($RS[$i].PNPDeviceID)) {
+        #   $pnpDevID=(scsiDiskParse $RS[$i].PNPDeviceID)
+        #} else {
+        #  Continue
+        #}
+
+        #if(($pnpDevID -eq $null) -or (($pnpDevID -eq "(Standard disk drives)") -and ($pnpDevID.product -eq $null))) {
+		#   $regex="^.{,16}$"
+        #    $pnpDevID=[pscustomobject]@{
+        #       product=($RS[$i].model -replace '^(.{0,16}).*$','$1')  # Strange behavior for this case, will return
+        #   }
+        #}
+
+        #$tmpManufacturer=$pnpDevID.vendor 
+        #$tmpModel=$pnpDevID.product 
+        #$tmpSerial=$RS[$i].serialnumber
+        #$tmpRevision=$pnpDevID.revision
+
+		Write-Progress -Id 3 -ParentId 2 -Activity "Collecting Hard Disk data" -CurrentOperation "Collecting manufacturer" -PercentComplete 0
+        $tmpManufacturer=$RS[$i].manufacturer
+        Write-Progress -Id 3 -ParentId 2 -Activity "Collecting Hard Disk data" -CurrentOperation "Collecting model" -PercentComplete 30
+        $tmpModel=($RS[$i].model -replace '^(.{0,16}).*$','$1')
+		Write-Progress -Id 3 -ParentId 2 -Activity "Collecting Hard Disk data" -CurrentOperation "Collecting serial" -PercentComplete 60
+        $tmpSerial=$RS[$i].serialnumber
+		
+		Write-Progress -Id 3 -ParentId 2 -Activity "Gathering Hard Disk information" -CurrentOperation "Cleaning output" -PercentComplete 90
+		
+        if ([string]::IsNullOrEmpty($tmpManufacturer) -or ($tmpManufacturer.Trim().Length -eq 0) -or ($tmpManufacturer.Trim() -eq "NVMe")) {
+            $tmpManufacturer="$NOT_SPECIFIED"
+        }
+        $tmpManufacturer=$(jsonManufacturer "$tmpManufacturer".Trim())
+
+        if ([string]::IsNullOrEmpty($tmpModel) -or ($tmpModel.Trim().Length -eq 0)) {
+            $tmpModel="$NOT_SPECIFIED"
+        }
+        $tmpModel=$(jsonModel "$tmpModel".Trim())
+
+        if (![string]::IsNullOrEmpty($tmpSerial) -and ($tmpSerial.Trim().Length -ne 0)) {
+            $tmpSerial=$(jsonSerial ("$tmpSerial".Trim() -replace '[\x00-\x20]+$' ,''))
+        } else {
+            $tmpSerial=""
+        }
+
+        if (![string]::IsNullOrEmpty($tmpRevision) -and ($tmpRevision.Trim().Length -ne 0)) {
+            $tmpRevision=$(jsonRevision "$tmpRevision".Trim())
+        } else {
+            $tmpRevision=""
+        }
+
+        $tmpComponent=$(jsonComponent $hddClass $tmpManufacturer $tmpModel $replaceable $tmpSerial $tmpRevision)
+        $component+="$tmpComponent,"
+		Write-Progress -Id 3 -ParentId 2 -Activity "Gathering Hard Disk information" -CurrentOperation "Cleaning output" -Completed
+    }
+
+    Write-Progress -Id 2 -ParentId 1 -Activity "Gathering Hard Disk information" -CurrentOperation "Done" -Completed
+    return "$component".Trim(",")
+}
+
+function parseNvmeData() {
+	Write-Progress -Id 2 -ParentId 1 -Activity "Gathering NVMe Disk information" -CurrentOperation "Collecting data from Powershell and Windows" -PercentComplete 0
+    $RS=((Get-PhysicalDisk | Where-Object BusType -eq NVMe).DeviceID)
+    $component=""
+    $replaceable=(jsonFieldReplaceable "true") # Looking for reliable indicator
+
+    $hddClass=$(jsonComponentClass "$COMPCLASS_REGISTRY_TCG" "$COMPCLASS_HDD")
+
+    $nvme=$(Get-NVMeIdentifyData $RS)
+    $numRows=$RS.Count
+
+    for($i=0;$i -lt $numRows;$i++) {
+        Write-Progress -Id 2 -ParentId 1 -Activity "Gathering NVMe Disk information" -CurrentOperation ("Parsing data from Windows for NVMe Disk " + ($i+1)) -PercentComplete ((($i+1) / $numRows) * 100)
+
+        $tmpManufacturer=""
+		Write-Progress -Id 3 -ParentId 2 -Activity "Collecting NVMe Disk data" -CurrentOperation "Collecting model" -PercentComplete 30
+        $tmpModel=(NvmeGetModelNumberForDeviceNumber $nvme $RS[$i])
+		Write-Progress -Id 3 -ParentId 2 -Activity "Collecting NVMe Disk data" -CurrentOperation "Collecting serial" -PercentComplete 60
+        $tmpSerial=(NvmeGetNguidForDevice $nvme $RS[$i]) 
+        if ("$tmpSerial" -match "^[0]+$") {
+            $tmpSerial=(NvmeGetEuiForDevice $nvme $RS[$i])
+        }
+		
+		Write-Progress -Id 3 -ParentId 2 -Activity "Gathering NVMe Disk information" -CurrentOperation "Cleaning output" -PercentComplete 90
+
+        if ([string]::IsNullOrEmpty($tmpManufacturer) -and [string]::IsNullOrEmpty($tmpModel) -and [string]::IsNullOrEmpty($tmpSerial) -and [string]::IsNullOrEmpty($tmpRevision)) {
+            Continue;
+        }
+
+        if ([string]::IsNullOrEmpty($tmpManufacturer) -or ($tmpManufacturer.Trim().Length -eq 0)) {
+            $tmpManufacturer="$NOT_SPECIFIED"
+        }
+        $tmpManufacturer=$(jsonManufacturer "$tmpManufacturer".Trim())
+
+        if ([string]::IsNullOrEmpty($tmpModel) -or ($tmpModel.Trim().Length -eq 0)) {
+            $tmpModel="$NOT_SPECIFIED"
+        } else {
+            $tmpModel=($tmpModel -replace '^(.{0,16}).*$','$1') # Reformatting for consistency for now.
+        }
+        $tmpModel=$(jsonModel "$tmpModel".Trim())
+
+        if (![string]::IsNullOrEmpty($tmpSerial) -and ($tmpSerial.Trim().Length -ne 0)) {
+            $tmpSerial=("$tmpSerial".Trim())
+            $tmpSerial=($tmpSerial -replace "(.{4})", '$1_' -replace "_$", '.') # Reformatting for consistency for now.
+            $tmpSerial=$(jsonSerial $tmpSerial)
+        } else {
+            $tmpSerial=""
+        }
+
+        if (![string]::IsNullOrEmpty($tmpRevision) -and ($tmpRevision.Trim().Length -ne 0)) {
+            $tmpRevision=$(jsonRevision "$tmpRevision".Trim())
+        } else {
+            $tmpRevision=""
+        }
+        $tmpComponent=$(jsonComponent $hddClass $tmpManufacturer $tmpModel $replaceable $tmpSerial $tmpRevision)
+        $component+="$tmpComponent,"
+		Write-Progress -Id 3 -ParentId 2 -Activity "Gathering NVMe Disk information" -CurrentOperation "Cleaning output" -Completed
+    }
+    Write-Progress -Id 2 -ParentId 1 -Activity "Gathering NVMe Disk information" -CurrentOperation "Done" -Completed
+    return "$component".Trim(",")
+}
+
+function parseGfxData() {
+	Write-Progress -Id 2 -ParentId 1 -Activity "Gathering GFX information" -CurrentOperation "Collecting data from Powershell" -PercentComplete 0
+    $RS=(Get-CimInstance -ClassName CIM_VideoController | Select-Object pnpdeviceid )
+    $component=""
+    $replaceable=(jsonFieldReplaceable "true")
+    $numRows=1
+    if ($RS.Count -gt 1) {
+        $numRows=($RS.Count)
+    }
+	
+	$gfxClass=(jsonComponentClass "$COMPCLASS_REGISTRY_TCG" "$COMPCLASS_GFX")
+	
+    for($i=0;$i -lt $numRows;$i++) {
+        Write-Progress -Id 2 -ParentId 1 -Activity "Gathering Graphics information" -CurrentOperation ("Parsing data from Powershell for HDD " + ($i+1)) -PercentComplete ((($i+1) / $numRows) * 100)
+
+        $pnpDevID=""
+        if(isPCI($RS[$i].PNPDeviceID)) {
+            $pnpDevID=$(pciParse $RS[$i].PNPDeviceID)
+        } else {
+            Continue
+        }
+
+		Write-Progress -Id 3 -ParentId 2 -Activity "Collecting Graphics data" -CurrentOperation "Collecting manufacturer" -PercentComplete 0
+        $tmpManufacturer=$pnpDevID.vendor # PCI Vendor ID
+		Write-Progress -Id 3 -ParentId 2 -Activity "Collecting Graphics data" -CurrentOperation "Collecting model" -PercentComplete 30
+        $tmpModel=$pnpDevID.product  # PCI Device Hardware ID
+		Write-Progress -Id 3 -ParentId 2 -Activity "Collecting Graphics data" -CurrentOperation "Collecting revision" -PercentComplete 60
+        $tmpRevision=$pnpDevID.revision
+        # CIM Class does not contain serialnumber
+
+		Write-Progress -Id 3 -ParentId 2 -Activity "Gathering Graphics information" -CurrentOperation "Cleaning output" -PercentComplete 90
+
+        if ([string]::IsNullOrEmpty($tmpManufacturer) -or ($tmpManufacturer.Trim().Length -eq 0)) {
+            $tmpManufacturer="$NOT_SPECIFIED"
+        }
+        $tmpManufacturer=$(jsonManufacturer "$tmpManufacturer".Trim())
+
+        if ([string]::IsNullOrEmpty($tmpModel) -or ($tmpModel.Trim().Length -eq 0)) {
+            $tmpModel="$NOT_SPECIFIED"
+        }
+        $tmpModel=$(jsonModel "$tmpModel".Trim())
+
+        if (![string]::IsNullOrEmpty($tmpRevision) -and ($tmpRevision.Trim().Length -ne 0)) {
+            $tmpRevision=$(jsonRevision "$tmpRevision".Trim())
+        } else {
+            $tmpRevision=""
+        }
+
+        $tmpComponent=$(jsonComponent $gfxClass $tmpManufacturer $tmpModel $replaceable $tmpRevision)
+        $component+="$tmpComponent,"
+		Write-Progress -Id 3 -ParentId 2 -Activity "Gathering Graphics information" -CurrentOperation "Cleaning output" -Completed
+    }
+
+    Write-Progress -Id 2 -ParentId 1 -Activity "Gathering Graphics information" -CurrentOperation "Done" -Completed
+    return "$component".Trim(",")
+}
+
+### Collate the component details
+function collectOldTcgRegistryComponents () {
+	Write-Progress -Id 2 -Activity "Gathering component details" -PercentComplete 10
+	$componentChassis=$(parseChassisData)
+	Write-Progress -Id 2 -Activity "Gathering component details" -PercentComplete 20
+	$componentBaseboard=$(parseBaseboardData)
+	Write-Progress -Id 2 -Activity "Gathering component details" -PercentComplete 30
+	$componentBios=$(parseBiosData)
+	Write-Progress -Id 2 -Activity "Gathering component details" -PercentComplete 40
+	$componentsCPU=$(parseCpuData)
+	Write-Progress -Id 2 -Activity "Gathering component details" -PercentComplete 50
+	$componentsRAM=$(parseRamData)
+	Write-Progress -Id 2 -Activity "Gathering component details" -PercentComplete 60
+	$componentsNIC=$(parseNicData)
+	Write-Progress -Id 2 -Activity "Gathering component details" -PercentComplete 70
+	$componentsHDD=$(parseHddData)
+	Write-Progress -Id 2 -Activity "Gathering component details" -PercentComplete 80
+	$componentsNVMe=$(parseNvmeData)
+	Write-Progress -Id 2 -Activity "Gathering component details" -PercentComplete 90
+	$componentsGFX=$(parseGfxData)
+	$componentList=$(toCSV "$componentChassis" "$componentBaseboard" "$componentBios" "$componentsCPU" "$componentsRAM" "$componentsNIC" "$componentsHDD" "$componentsNVMe" "$componentsGFX")
+
+	Write-Progress -Id 2 -Activity "Gathering component details" -CurrentOperation "Done" -Completed
+    return "$componentList"
+}
+
+function collectProperties () {
+    Write-Progress -Id 2 -Activity "Gathering properties" -PercentComplete 10
+    $osCaption=$((Get-WmiObject -Class Win32_OperatingSystem).caption)
+    if ($null -ne $osCaption) {
+        $osCaption = $osCaption.Trim()
+    }
+    $property1=$(jsonProperty "caption" "$osCaption")  ## Example1
+    #$property2=(jsonProperty "caption" "$osCaption" "$JSON_STATUS_ADDED") ## Example with optional third status argument
+
+    $propertyList=$(toCSV "$property1")
+
+    Write-Progress -Id 2 -Activity "Gathering properties" -CurrentOperation "Done" -Completed
+    return "$propertyList"
+}
+
+if (![string]::IsNullOrEmpty($printoutfile)) {
+    $componentList=$(collectOldTcgRegistryComponents)
+
+    $output=$componentList
+    if (!$componentsonly) {
+        $platformList=$(parseSystemData)
+        $propertyList=$(collectProperties)
+
+        $platformObject=$(jsonPlatformObject "$platformList")
+        $componentArray=$(jsonComponentArray "$componentList")
+        $propertyArray=$(jsonPropertyArray "$propertyList")
+
+        #$componentsUri=$(jsonComponentsUri "https:// example.uri/componentpolicy.pdf" "C:/path/to/local/fileToHash")
+        #$propertiesUri=(jsonPropertiesUri "https:// example.uri/propertypolicy.pdf" "C:/path/to/local/fileToHash")
+        $output=$(jsonIntermediateFile "$platformObject" "$componentArray" "$propertyArray")
+    }
+
+    [IO.File]::WriteAllText($printoutfile, "$output")
+}

--- a/src/main/java/cli/DeviceObserverCli.java
+++ b/src/main/java/cli/DeviceObserverCli.java
@@ -68,13 +68,13 @@ public class DeviceObserverCli {
         IssuerSerial issuerSerial = null;
         boolean delta = false;
         
-        try {
+        try {// Attempt to parse holder as a PK certificate
             ekCert = (X509CertificateHolder)CliHelper.loadCert(ekCertFile, x509type.CERTIFICATE);
             issuerSerial = new IssuerSerial(ekCert.getIssuer(), ekCert.getSerialNumber());
-        } catch (IOException e) {
+        } catch (Exception e) {
             
         }
-        try {
+        try {// Attempt to parse holder as an attribute certificate. If so, create a delta certificate.
             pCert = (X509AttributeCertificateHolder)CliHelper.loadCert(ekCertFile, x509type.ATTRIBUTE_CERTIFICATE);
             delta = true;
             // X509AttributeCertificateHolder does not extract a compatible IssuerSerial object 
@@ -84,7 +84,7 @@ public class DeviceObserverCli {
                 gns[i] = new GeneralName(parts[i]);
             }
             issuerSerial = new IssuerSerial(new GeneralNames(gns), pCert.getSerialNumber());
-        } catch (IOException e) {
+        } catch (Exception e) {
             
         }
         


### PR DESCRIPTION
New gradle tasks can bundle together a paccor distributable package. distZipWin, distZipLinux will look for the .NET standalone executables built for each platform in bin folders under dotnet/ComponentClassRegistry. In the distributable, the utilties will be placed in the scripts or scripts/windows folder, depending on the platform target.

The bash and powershell scripts were updated in the same way:
* json structure utilities were moved to a json.sh/.ps1 script that can be used by any other scripts.
* allcomponents will by default collect component information from the SMBIOS, PCIe, and Storage registry utilities bundled.
* allcomponents can be configured to also include component information gathered in previous paccor versions.
* tcg_ccr.sh/ps1 contains those methods that were used to gather component information in previous paccor versions. That information was labeled according to the original TCG Component Class Registry. This document does not specify how to translate component information into the platform certificate, and that led to situations of inoperability that should be solved by the newer registries.