### PR TITLE
Update pc_certgen.ps1 - Fix Error: "String was not recognized as a va…

### DIFF
--- a/scripts/windows/pc_certgen.ps1
+++ b/scripts/windows/pc_certgen.ps1
@@ -125,7 +125,7 @@ echo "All JSON structures look valid."
 # Step 6 create a sample signing key pair
 if (!(Test-Path "$pcsigncert" -PathType Leaf)) {
     echo "Creating a signing key for signing platform credentials"
-    $newcert=(New-SelfSignedCertificate -Type Custom -KeyExportPolicy Exportable -Subject "$subjectDN" -KeyUsage DigitalSignature -KeyAlgorithm "$sigalg" -KeyLength "$sigalgbits" -NotAfter "$daysValid" -CertStoreLocation "$certStoreLocation")
+    $newcert=(New-SelfSignedCertificate -Type Custom -KeyExportPolicy Exportable -Subject "$subjectDN" -KeyUsage DigitalSignature -KeyAlgorithm "$sigalg" -KeyLength "$sigalgbits" -NotAfter ([datetime]"$daysValid") -CertStoreLocation "$certStoreLocation")
     if (!$?) {
         echo "Failed to create the key pair, exiting"
         exit 1


### PR DESCRIPTION
While using the Windows script I get the error:

```
New-SelfSignedCertificate : Cannot bind parameter 'NotAfter'. Cannot convert value "07/14/2035 16:13:01" to type        "System.DateTime". Error: "String was not recognized as a valid DateTime."                                              At C:\Users\...\Downloads\paccor.1.5.0-beta2.win-x64\paccor-1.5.0beta2\scripts\windows\pc_certgen.ps1:128 char:190 + ... thm "$sigalg" -KeyLength "$sigalgbits" -NotAfter "$daysValid" -CertSt ...                                         +                                                      ~~~~~~~~~~~~                                                         + CategoryInfo          : InvalidArgument: (:) [New-SelfSignedCertificate], ParameterBindingException                   + FullyQualifiedErrorId : CannotConvertArgumentNoMessage,Microsoft.CertificateServices.Commands.NewSelfSignedCerti     ficateCommand                                                                                                                                                                                                                                Failed to create the key pair, exiting
```

Fixing with a cast