### PR TITLE
Cannot use ReadAllBytes to read pci sys files

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -8,7 +8,7 @@ plugins {
 
 // version number
 def base_version = '1.5.0'
-def base_release = 'beta4'
+def base_release = 'beta5'
 def archive_version = "${base_version}-${base_release}"
 
 version = "${base_version}${base_release}"

--- a/dotnet/ComponentClassRegistry/Pcie/Pcie.Shared.props
+++ b/dotnet/ComponentClassRegistry/Pcie/Pcie.Shared.props
@@ -1,5 +1,5 @@
 <Project>
   <PropertyGroup>
-    <Version>0.8.0</Version>
+    <Version>0.8.1</Version>
   </PropertyGroup>
 </Project>

--- a/scripts/hw.sh
+++ b/scripts/hw.sh
@@ -85,7 +85,7 @@ lshwGetVersionFromBusItem () {
 lshwGetSerialFromBusItem () {
     itemNumber="${1}"
     result=""
-    str=$(echo "${busitems[$itemNumber]}" | grep -e "^serial:.*$" | sed 's/^serial: \([0-9A-Za-z:-]\+\)$/\1/')
+    str=$(echo "${busitems[$itemNumber]}" | grep -e "^serial:.*$" | sed 's/^serial: \([^\\\"\x00-\x1F\[]\+\)$/\1/')
     if [ -n "$str" ]; then
         result=$str
     fi
@@ -103,7 +103,7 @@ lshwGetLogicalNameFromBusItem () {
 lshwGetVendorNameFromBusItem () {
     itemNumber="${1}"
     result=""
-    str=$(echo "${busitems[$itemNumber]}" | grep -e "^vendor:.*$" | sed 's/^vendor: \([0-9A-Za-z -]\+\) \?\[\?.*$/\1/')
+    str=$(echo "${busitems[$itemNumber]}" | grep -e "^vendor:.*$" | sed 's/^vendor: \([^\\\"\x00-\x1F\[]\+\).*$/\1/')
     if [ -n "$str" ]; then
         result=$str
     fi
@@ -112,7 +112,7 @@ lshwGetVendorNameFromBusItem () {
 lshwGetProductNameFromBusItem () {
     itemNumber="${1}"
     result=""
-    str=$(echo "${busitems[$itemNumber]}" | grep -e "^product:.*$" | sed 's/^product: \([0-9A-Za-z\(\) -]\+\) \?\[\?.*$/\1/')
+    str=$(echo "${busitems[$itemNumber]}" | grep -e "^product:.*$" | sed 's/^product: \([^\\\"\x00-\x1F\[]\+\).*$/\1/')
     if [ -n "$str" ]; then
         result=$str
     fi

--- a/scripts/nvme.sh
+++ b/scripts/nvme.sh
@@ -2,12 +2,11 @@
 # Gather descriptors for NVMe devices  
 nvmeParse () {
     str=$(nvme list -o json -v)
-    count=$(echo "$str" | jq '.Devices | length')
+    controllers=$(echo "$str" | jq -r '.Devices[].Subsystems[].Controllers[].Controller')
     nvmeDevices=()
 
-    for ((i = 0 ; i < count ; i++ )); do
-        elementJson=$(echo "$str" | jq -r .Devices["$i"].Subsystems[0].Controllers[0].Controller)
-        elementJson="/dev/$elementJson"
+    for path in $controllers; do
+        elementJson="/dev/$path"
         nvmeDevices+=("$elementJson") 
     done
 }

--- a/scripts/nvme.sh
+++ b/scripts/nvme.sh
@@ -2,7 +2,7 @@
 # Gather descriptors for NVMe devices  
 nvmeParse () {
     str=$(nvme list -o json -v)
-    controllers=$(echo "$str" | jq -r '.Devices[].Subsystems[].Controllers[].Controller')
+    controllers=$(echo "$str" | jq -r '.Devices[].Subsystems[].Controllers[].Controller' 2> /dev/null)
     nvmeDevices=()
 
     for path in $controllers; do


### PR DESCRIPTION
Standard ReadAllBytes uses FileShare.Read that can block access to the file during read.
This can cause a race condition when the kernel attempts to update the system files I'm wanting to read.
FileShare.ReadWrite | FileShare.Delete should allow full concurrent access

Also made some changes to nvme and hw linux scripts.