### PR TITLE
Fix AIA/CRL locations encoded as directoryName instead of URI

### DIFF
--- a/src/main/java/json/OtherExtensionsJsonHelper.java
+++ b/src/main/java/json/OtherExtensionsJsonHelper.java
@@ -82,7 +82,7 @@ public class OtherExtensionsJsonHelper {
                             final JsonNode methodNode = elementNode.get(ElementJson.ACCESSMETHOD.name());
                             final JsonNode locationNode = elementNode.get(ElementJson.ACCESSLOCATION.name());
                             
-                            aiaf.addElement(MethodJson.valueOf(methodNode.asText()), new GeneralName(new X500Name(locationNode.asText())));
+                            aiaf.addElement(MethodJson.valueOf(methodNode.asText()), parseGeneralName(locationNode.asText()));
                         }
                     }
                 }
@@ -115,10 +115,10 @@ public class OtherExtensionsJsonHelper {
                         final JsonNode typeNode = distNameNode.get(CrlJson.TYPE.name());
                         final JsonNode nameNode = distNameNode.get(CrlJson.NAME.name());
                         
-                        dpn = new DistributionPointName(typeNode.asInt(), new GeneralNames(new GeneralName(new X500Name(nameNode.asText()))));
+                        dpn = new DistributionPointName(typeNode.asInt(), new GeneralNames(parseGeneralName(nameNode.asText())));
                     }
                     
-                    cdf = new CRLDistPoint(new DistributionPoint[]{new DistributionPoint(dpn, new ReasonFlags(reasonNode.asInt()), new GeneralNames(new GeneralName(new X500Name(issuerNode.asText()))))});
+                    cdf = new CRLDistPoint(new DistributionPoint[]{new DistributionPoint(dpn, new ReasonFlags(reasonNode.asInt()), new GeneralNames(parseGeneralName(issuerNode.asText())))});
                 }
             }
         } catch (IOException e) {
@@ -126,6 +126,16 @@ public class OtherExtensionsJsonHelper {
         }
             
         return cdf;
+    }
+
+    private static GeneralName parseGeneralName(final String value) {
+        final String trimmed = value == null ? "" : value.trim();
+        final String lower = trimmed.toLowerCase();
+        if (lower.startsWith("http://") || lower.startsWith("https://")
+                || lower.startsWith("ldap://") || lower.startsWith("ldaps://")) {
+            return new GeneralName(GeneralName.uniformResourceIdentifier, trimmed);
+        }
+        return new GeneralName(new X500Name(trimmed));
     }
     
     public static final TargetingInformationFactory ekTargetsFromJsonFile(final String filename) {

--- a/src/main/java/json/OtherExtensionsJsonHelper.java
+++ b/src/main/java/json/OtherExtensionsJsonHelper.java
@@ -114,11 +114,17 @@ public class OtherExtensionsJsonHelper {
                     if (distNameNode.has(CrlJson.TYPE.name()) && distNameNode.has(CrlJson.NAME.name())) {
                         final JsonNode typeNode = distNameNode.get(CrlJson.TYPE.name());
                         final JsonNode nameNode = distNameNode.get(CrlJson.NAME.name());
-                        
-                        dpn = new DistributionPointName(typeNode.asInt(), new GeneralNames(parseGeneralName(nameNode.asText())));
+
+                        // TYPE=0 (fullName): URI or DN; TYPE=1 (nameRelativeToCRLIssuer): always RDN
+                        if (typeNode.asInt() == 0) {
+                            dpn = new DistributionPointName(0, new GeneralNames(parseGeneralName(nameNode.asText())));
+                        } else {
+                            dpn = new DistributionPointName(typeNode.asInt(), new GeneralNames(new GeneralName(new X500Name(nameNode.asText()))));
+                        }
                     }
-                    
-                    cdf = new CRLDistPoint(new DistributionPoint[]{new DistributionPoint(dpn, new ReasonFlags(reasonNode.asInt()), new GeneralNames(parseGeneralName(issuerNode.asText())))});
+
+                    // crlIssuer is always a directoryName per RFC 5280 §4.2.1.13
+                    cdf = new CRLDistPoint(new DistributionPoint[]{new DistributionPoint(dpn, new ReasonFlags(reasonNode.asInt()), new GeneralNames(new GeneralName(new X500Name(issuerNode.asText()))))});
                 }
             }
         } catch (IOException e) {

--- a/src/test/resources/otherExt.json
+++ b/src/test/resources/otherExt.json
@@ -16,13 +16,13 @@
     "AUTHORITYINFOACCESS": [
         {
             "ACCESSMETHOD": "OCSP",
-            "ACCESSLOCATION": "CN=MyApp ACES CA 2, OU=MyApp Public Sector, O=MyApp, C=US"
+            "ACCESSLOCATION": "http://ocsp.example.com"
         }
     ],
     "CRLDISTRIBUTION": {
         "DISTRIBUTIONNAME": {
             "TYPE": "0",
-            "NAME": "CN=MyApp ACES CA 2, OU=MyApp Public Sector, O=MyApp, C=US"
+            "NAME": "http://crl.example.com/platform.crl"
         },
         "REASON": "8",
         "ISSUER": "CN=MyApp ACES CA 2, OU=MyApp Public Sector, O=MyApp, C=US"


### PR DESCRIPTION
## Summary

- AIA `accessLocation` and CRL distribution point names were always constructed as X.500 `directoryName` (GeneralName tag [4]), even when the value was an HTTP or LDAP URI
- Per IWG Profile v1.1 §3.2.12, the `accessLocation` value SHOULD point to the OCSP responder as an HTTP URI (`uniformResourceIdentifier`, GeneralName tag [6])
- Extract a `parseGeneralName()` helper that detects URI schemes (`http`, `https`, `ldap`, `ldaps`) and encodes them as `uniformResourceIdentifier`, falling back to `X500Name` for distinguished name values

## Test plan

- [ ] Verify AIA extension with HTTP URI is encoded as `uniformResourceIdentifier` (tag [6])
- [ ] Verify CRL distribution point with LDAP URI is encoded as `uniformResourceIdentifier` (tag [6])
- [ ] Verify X.500 DN values still encode as `directoryName` (tag [4])