### PR TITLE
validate should include serial in ComponentKey

### DIFF
--- a/src/main/java/paccor/cli/CliHelper.java
+++ b/src/main/java/paccor/cli/CliHelper.java
@@ -1,5 +1,7 @@
 package paccor.cli;
 
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
 import paccor.cert.CertKind;
 import paccor.exception.CertificateLoadException;
 import paccor.exception.PaccorException;
@@ -73,11 +75,45 @@ public class CliHelper {
     public static final byte[] derToPem(final String filename, final x509type type) throws IOException {
         byte[] buffer = Files.readAllBytes(Paths.get(filename));
         
-        if ((char)buffer[0] != '-') { // DER can start with a digit
+        if (!containsPemBlock(buffer, type)) { // If the buffer contains a PEM block, trust the PEM parser
             buffer = bytesToPem(buffer, type).getBytes();
         }
         
         return buffer;
+    }
+
+    /**
+     * Test if the byte array contains a PEM block.
+     * @param data byte array
+     * @param type x509type - type of PEM known to the project
+     * @return true if the byte array contains a PEM block, false otherwise.
+     */
+    public static final boolean containsPemBlock(final byte[] data, final x509type type) {
+        String header = type.getPemHeader().trim();
+        String footer = type.getPemFooter().trim();
+        return containsPemBlock(data, header, footer);
+    }
+
+    /**
+     * Test if the byte array contains a PEM block.
+     * @param data byte array
+     * @param header header string
+     * @param footer footer string
+     * @return true if the byte array contains a PEM block, false otherwise.
+     */
+    public static final boolean containsPemBlock(final byte[] data, final String header, final String footer) {
+        if (data == null || header == null || footer == null) {
+            return false;
+        }
+
+        String text = new String(data, StandardCharsets.UTF_8);
+
+        String regex = "^\\s*" + Pattern.quote(header) + ".*?" + "^\\s*" + Pattern.quote(footer);
+
+        Pattern pattern = Pattern.compile(regex, Pattern.MULTILINE | Pattern.DOTALL);
+        Matcher matcher = pattern.matcher(text);
+
+        return matcher.find();
     }
 
     public static final boolean parsesAsPkc(final String b64) {

--- a/src/main/java/paccor/cli/ValidateCmd.java
+++ b/src/main/java/paccor/cli/ValidateCmd.java
@@ -16,7 +16,7 @@ import java.util.Optional;
 import java.util.concurrent.Callable;
 import java.util.stream.Stream;
 import paccor.cli.pv.ReadableFileConverter;
-import paccor.json.ObjectMapperFactory;
+import paccor.json.HardwareManifestJsonHelper;
 import paccor.normalization.PlatformConfigurationNormalizer;
 import paccor.crypto.PcBcContentVerifierProviderBuilder;
 import org.bouncycastle.cert.CertException;
@@ -164,14 +164,15 @@ public class ValidateCmd implements Callable<Integer>, HasCommonOptions {
             }
             return false;
         }
-        PlatformConfiguration expectV1 = ObjectMapperFactory.fromJsonSafe(jsonFile, PlatformConfiguration.class);
-        PlatformConfigurationV2 expectV2 = ObjectMapperFactory.fromJsonSafe(jsonFile, PlatformConfigurationV2.class);
-        PlatformConfigurationV3 expectV3 = ObjectMapperFactory.fromJsonSafe(jsonFile, PlatformConfigurationV3.class);
+        HardwareManifestJsonHelper manifest = HardwareManifestJsonHelper.readComponents(jsonFile);
+        if (manifest == null) {
+            return false;
+        }
 
         List<TraitMap> expected = normalizeExpected(
-                expectV1,
-                expectV2,
-                expectV3,
+                manifest.pcV1(),
+                manifest.pcV2(),
+                manifest.pcV3(),
                 certificate.hasAttribute(TCGObjectIdentifier.tcgAtPlatformConfigurationV1),
                 certificate.hasAttribute(TCGObjectIdentifier.tcgAtPlatformConfigurationV2));
 
@@ -192,39 +193,62 @@ public class ValidateCmd implements Callable<Integer>, HasCommonOptions {
             PlatformConfigurationV3 expectV3,
             boolean requireV1Compatibility,
             boolean requireV2Compatibility) {
-        if (requireV1Compatibility && PlatformConfigurationNormalizer.hasContent(expectV1)) {
-            return PlatformConfigurationNormalizer.componentsForValidation(expectV1);
-        }
-        if (requireV1Compatibility && PlatformConfigurationNormalizer.hasContent(expectV3)) {
-            PlatformConfiguration downcast = PlatformConfigurationNormalizer.toV1(expectV3);
-            if (downcast == null) {
-                if (shouldPrintDetails()) {
-                    System.out.println("Expected component JSON cannot be represented as PlatformConfiguration.");
-                }
-                return null;
-            }
-            return PlatformConfigurationNormalizer.componentsForValidation(downcast);
-        }
-        if (requireV2Compatibility && PlatformConfigurationNormalizer.hasContent(expectV3)) {
-            PlatformConfigurationV2 downcast = PlatformConfigurationNormalizer.toV2(expectV3);
-            if (downcast == null) {
-                if (shouldPrintDetails()) {
-                    System.out.println("Expected component JSON cannot be represented as PlatformConfigurationV2.");
-                }
-                return null;
-            }
-            return PlatformConfigurationNormalizer.componentsForValidation(downcast);
+        return tryV1Compat(expectV1, expectV3, requireV1Compatibility)
+                .or(() -> tryV2Compat(expectV3, requireV2Compatibility))
+                .or(() -> tryDirect(expectV3, expectV2, expectV1))
+                .orElse(List.of());
+    }
+
+    private Optional<List<TraitMap>> tryV1Compat(
+            PlatformConfiguration expectV1,
+            PlatformConfigurationV3 expectV3,
+            boolean requireV1Compatibility) {
+        if (!requireV1Compatibility) return Optional.empty();
+        if (PlatformConfigurationNormalizer.hasContent(expectV1)) {
+            return Optional.of(PlatformConfigurationNormalizer.componentsForValidation(expectV1));
         }
         if (PlatformConfigurationNormalizer.hasContent(expectV3)) {
-            return PlatformConfigurationNormalizer.componentsForValidation(expectV3);
+            return Optional.ofNullable(PlatformConfigurationNormalizer.toV1(expectV3))
+                    .map(PlatformConfigurationNormalizer::componentsForValidation)
+                    .or(() -> {
+                        if (shouldPrintDetails()) {
+                            System.out.println("Expected component JSON cannot be represented as PlatformConfiguration.");
+                        }
+                        return Optional.empty();
+                    });
         }
-        if (PlatformConfigurationNormalizer.hasContent(expectV2)) {
-            return PlatformConfigurationNormalizer.componentsForValidation(expectV2);
+        return Optional.empty();
+    }
+
+    private Optional<List<TraitMap>> tryV2Compat(
+            PlatformConfigurationV3 expectV3,
+            boolean requireV2Compatibility) {
+        if (!requireV2Compatibility || !PlatformConfigurationNormalizer.hasContent(expectV3)) {
+            return Optional.empty();
         }
-        if (PlatformConfigurationNormalizer.hasContent(expectV1)) {
-            return PlatformConfigurationNormalizer.componentsForValidation(expectV1);
-        }
-        return List.of();
+        return Optional.ofNullable(PlatformConfigurationNormalizer.toV2(expectV3))
+                .map(PlatformConfigurationNormalizer::componentsForValidation)
+                .or(() -> {
+                    if (shouldPrintDetails()) {
+                        System.out.println("Expected component JSON cannot be represented as PlatformConfigurationV2.");
+                    }
+                    return Optional.empty();
+                });
+    }
+
+    private Optional<List<TraitMap>> tryDirect(
+            PlatformConfigurationV3 expectV3,
+            PlatformConfigurationV2 expectV2,
+            PlatformConfiguration expectV1) {
+        return Optional.ofNullable(expectV3)
+                .filter(PlatformConfigurationNormalizer::hasContent)
+                .map(PlatformConfigurationNormalizer::componentsForValidation)
+                .or(() -> Optional.ofNullable(expectV2)
+                        .filter(PlatformConfigurationNormalizer::hasContent)
+                        .map(PlatformConfigurationNormalizer::componentsForValidation))
+                .or(() -> Optional.ofNullable(expectV1)
+                        .filter(PlatformConfigurationNormalizer::hasContent)
+                        .map(PlatformConfigurationNormalizer::componentsForValidation));
     }
 
     private boolean compareNormalized(List<TraitMap> expected, List<TraitMap> actual, ComponentMatcher matcher) {

--- a/src/main/java/paccor/json/HardwareManifestJsonHelper.java
+++ b/src/main/java/paccor/json/HardwareManifestJsonHelper.java
@@ -30,14 +30,14 @@ import tools.jackson.databind.JsonNode;
 @JsonFormat(with = JsonFormat.Feature.ACCEPT_CASE_INSENSITIVE_PROPERTIES)
 @JsonIgnoreProperties(ignoreUnknown = true)
 public record HardwareManifestJsonHelper(
-    @JsonPropertyDescription("Platform Configuration Version 1 details.")
-    PlatformConfiguration pcV1,
-    @JsonPropertyDescription("Platform Configuration Version 2 details.")
-    PlatformConfigurationV2 pcV2,
-    @JsonPropertyDescription("Platform Configuration Version 3 details.")
-    PlatformConfigurationV3 pcV3,
-    @JsonPropertyDescription("Trait-based platform identifier data derived from the hardware manifest.")
-    TraitMap platformTraits) {
+        @JsonPropertyDescription("Platform Configuration Version 1 details.")
+        PlatformConfiguration pcV1,
+        @JsonPropertyDescription("Platform Configuration Version 2 details.")
+        PlatformConfigurationV2 pcV2,
+        @JsonPropertyDescription("Platform Configuration Version 3 details.")
+        PlatformConfigurationV3 pcV3,
+        @JsonPropertyDescription("Trait-based platform identifier data derived from the hardware manifest.")
+        TraitMap platformTraits) {
 
     public static final HardwareManifestJsonHelper fromJsonNode(JsonNode node) {
         if (node == null || node.isNull()) return null;
@@ -102,19 +102,19 @@ public record HardwareManifestJsonHelper(
      * @return platform configuration v3
      */
     private static PlatformConfigurationV3 resolvePcv3(String jsonString, JsonNode node, PlatformConfiguration pcV1, PlatformConfigurationV2 pcV2) {
-        PlatformConfigurationV3 pcV3 = ObjectMapperFactory.fromJsonSafe(jsonString, PlatformConfigurationV3.class);
+        PlatformConfigurationV3 pcV3 = buildPcv3FromNode(node);
         if (pcV3 == null) {
-            pcV3 = buildPcv3FromNode(node);
+            pcV3 = ObjectMapperFactory.fromJsonSafe(jsonString, PlatformConfigurationV3.class);
         }
         return pcV3 != null ? pcV3 : canonicalize(pcV1, pcV2);
     }
 
     private static PlatformConfigurationV3 resolvePcv3(File componentsJson, PlatformConfiguration pcV1, PlatformConfigurationV2 pcV2) {
-        PlatformConfigurationV3 pcV3 = ObjectMapperFactory.fromJsonSafe(componentsJson, PlatformConfigurationV3.class);
+        PlatformConfigurationV3 pcV3 = readJsonNode(componentsJson)
+                .map(HardwareManifestJsonHelper::buildPcv3FromNode)
+                .orElse(null);
         if (pcV3 == null) {
-            pcV3 = readJsonNode(componentsJson)
-                    .map(HardwareManifestJsonHelper::buildPcv3FromNode)
-                    .orElse(null);
+            pcV3 = ObjectMapperFactory.fromJsonSafe(componentsJson, PlatformConfigurationV3.class);
         }
         return pcV3 != null ? pcV3 : canonicalize(pcV1, pcV2);
     }
@@ -139,10 +139,7 @@ public record HardwareManifestJsonHelper(
 
     private static List<TraitMap> readPlatformComponents(JsonNode comps) {
         List<TraitMap> components = new ArrayList<>();
-        if (comps == null || !comps.isArray()) {
-            return components;
-        }
-        for (JsonNode node : comps) {
+        for (JsonNode node : asNodeList(comps)) {
             TraitMap tm = readTraitMap(node);
             if (tm != null && !tm.isEmpty()) {
                 components.add(tm);
@@ -169,10 +166,7 @@ public record HardwareManifestJsonHelper(
 
     private static List<PlatformPropertiesV2> readPlatformProperties(JsonNode props) {
         List<PlatformPropertiesV2> out = new ArrayList<>();
-        if (props == null || !props.isArray()) {
-            return out;
-        }
-        for (JsonNode p : props) {
+        for (JsonNode p : asNodeList(props)) {
             try {
                 PlatformPropertiesV2 prop = ObjectMapperFactory.fromJsonNode(p, PlatformPropertiesV2.class);
                 if (prop != null) {
@@ -181,5 +175,19 @@ public record HardwareManifestJsonHelper(
             } catch (Exception ignored) { }
         }
         return out;
+    }
+
+    private static List<JsonNode> asNodeList(JsonNode node) {
+        if (node == null || node.isNull()) {
+            return List.of();
+        }
+        if (node.isArray()) {
+            List<JsonNode> out = new ArrayList<>();
+            for (JsonNode child : node) {
+                out.add(child);
+            }
+            return out;
+        }
+        return List.of(node);
     }
 }

--- a/src/main/java/paccor/json/ObjectMapperFactory.java
+++ b/src/main/java/paccor/json/ObjectMapperFactory.java
@@ -4,6 +4,7 @@ import paccor.exception.JsonException;
 import java.io.File;
 import java.nio.file.Files;
 import tools.jackson.core.JacksonException;
+import tools.jackson.databind.DeserializationFeature;
 import tools.jackson.databind.JsonNode;
 import tools.jackson.databind.ObjectMapper;
 import tools.jackson.databind.ObjectWriter;
@@ -17,6 +18,7 @@ public final class ObjectMapperFactory {
 
     public static final ObjectMapper create() {
         return JsonMapper.builder()
+                .enable(DeserializationFeature.ACCEPT_SINGLE_VALUE_AS_ARRAY)
                 .addModule(new JacksonAsn1Module())
                 .build();
     }

--- a/src/main/java/paccor/tcg/credential/ComponentIdentifierV2.java
+++ b/src/main/java/paccor/tcg/credential/ComponentIdentifierV2.java
@@ -9,6 +9,7 @@ import jakarta.validation.constraints.Size;
 import java.util.Arrays;
 import java.util.List;
 import java.util.Optional;
+import java.util.stream.Stream;
 import paccor.json.schema.ComponentSchema;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
@@ -189,12 +190,9 @@ public class ComponentIdentifierV2 extends ASN1Object {
          */
         public final void componentAddressesFromSequence(@NonNull ASN1Sequence seq) {
             Optional.ofNullable(ASN1Utils.safeGetDefaultElement(seq, null, ComponentAddress::getInstance))
-                    .ifPresentOrElse(
-                            this::componentAddress,
-                            () ->
-                                Arrays.asList(seq.toArray()).forEach(
-                                        element ->
-                                                this.componentAddress(ComponentAddress.getInstance(element))));
+                    .map(List::of)
+                    .orElseGet(() -> Stream.of(seq.toArray()).map(ComponentAddress::getInstance).toList())
+                    .forEach(this::componentAddress);
         }
     }
 }

--- a/src/main/java/paccor/tcg/credential/PlatformConfiguration.java
+++ b/src/main/java/paccor/tcg/credential/PlatformConfiguration.java
@@ -1,8 +1,10 @@
 package paccor.tcg.credential;
 
+import com.fasterxml.jackson.annotation.JsonFormat;
 import jakarta.validation.constraints.Size;
-import java.util.Arrays;
 import java.util.List;
+import java.util.Optional;
+import java.util.stream.Stream;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.EqualsAndHashCode;
@@ -41,9 +43,11 @@ public class PlatformConfiguration extends ASN1Object {
 	private static final int MIN_SEQUENCE_SIZE = 0;
 	private static final int MAX_SEQUENCE_SIZE = 3;
 
+	@JsonFormat(with = JsonFormat.Feature.ACCEPT_SINGLE_VALUE_AS_ARRAY)
 	@Singular
 	@Size(min = 1)
 	private final List<ComponentIdentifier> componentIdentifiers; // optional, tagged 0
+	@JsonFormat(with = JsonFormat.Feature.ACCEPT_SINGLE_VALUE_AS_ARRAY)
 	@Singular
 	@Size(min = 1)
 	private final List<PlatformProperties> platformProperties; // optional, tagged 1
@@ -115,9 +119,10 @@ public class PlatformConfiguration extends ASN1Object {
 		 * @param seq ASN1Sequence
 		 */
 		public final void componentIdentifiersFromSequence(@NonNull ASN1Sequence seq) {
-			Arrays.asList(seq.toArray()).forEach(
-					element ->
-							this.componentIdentifier(ComponentIdentifier.getInstance(element)));
+			Optional.ofNullable(ASN1Utils.safeGetDefaultElement(seq, null, ComponentIdentifier::getInstance))
+					.map(List::of)
+					.orElseGet(() -> Stream.of(seq.toArray()).map(ComponentIdentifier::getInstance).toList())
+					.forEach(this::componentIdentifier);
 		}
 
 		/**
@@ -125,9 +130,10 @@ public class PlatformConfiguration extends ASN1Object {
 		 * @param seq ASN1Sequence
 		 */
 		public final void platformPropertiesFromSequence(@NonNull ASN1Sequence seq) {
-			Arrays.asList(seq.toArray()).forEach(
-					element ->
-							this.platformProperty(PlatformProperties.getInstance(element)));
+			Optional.ofNullable(ASN1Utils.safeGetDefaultElement(seq, null, PlatformProperties::getInstance))
+					.map(List::of)
+					.orElseGet(() -> Stream.of(seq.toArray()).map(PlatformProperties::getInstance).toList())
+					.forEach(this::platformProperty);
 		}
 	}
 }

--- a/src/main/java/paccor/tcg/credential/PlatformConfigurationV2.java
+++ b/src/main/java/paccor/tcg/credential/PlatformConfigurationV2.java
@@ -6,8 +6,9 @@ import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.annotation.JsonPropertyDescription;
 import jakarta.validation.constraints.Size;
-import java.util.Arrays;
 import java.util.List;
+import java.util.Optional;
+import java.util.stream.Stream;
 import paccor.json.schema.HardwareManifestSchema;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
@@ -53,6 +54,7 @@ public class PlatformConfigurationV2 extends ASN1Object {
 	private static final int MIN_SEQUENCE_SIZE = 0;
 	private static final int MAX_SEQUENCE_SIZE = 4;
 
+	@JsonFormat(with = JsonFormat.Feature.ACCEPT_SINGLE_VALUE_AS_ARRAY)
 	@JsonProperty(HardwareManifestSchema.COMPONENTS)
 	@JsonPropertyDescription("Platform components in the legacy v1.1 component identifier form.")
 	@Singular
@@ -61,6 +63,7 @@ public class PlatformConfigurationV2 extends ASN1Object {
 	@JsonProperty(HardwareManifestSchema.COMPONENTS_URI)
 	@JsonPropertyDescription("Optional URI reference for externally hosted component identifiers.")
 	private final URIReference componentIdentifiersUri; // optional, tagged 1
+	@JsonFormat(with = JsonFormat.Feature.ACCEPT_SINGLE_VALUE_AS_ARRAY)
 	@JsonProperty(HardwareManifestSchema.PROPERTIES)
 	@JsonPropertyDescription("Platform properties.")
 	@Singular
@@ -140,9 +143,10 @@ public class PlatformConfigurationV2 extends ASN1Object {
 		 * @param seq ASN1Sequence
 		 */
 		public final void componentIdentifiersFromSequence(@NonNull ASN1Sequence seq) {
-			Arrays.asList(seq.toArray()).forEach(
-					element ->
-							this.componentIdentifier(ComponentIdentifierV2.getInstance(element)));
+			Optional.ofNullable(ASN1Utils.safeGetDefaultElement(seq, null, ComponentIdentifierV2::getInstance))
+					.map(List::of)
+					.orElseGet(() -> Stream.of(seq.toArray()).map(ComponentIdentifierV2::getInstance).toList())
+					.forEach(this::componentIdentifier);
 		}
 
 		/**
@@ -150,9 +154,10 @@ public class PlatformConfigurationV2 extends ASN1Object {
 		 * @param seq ASN1Sequence
 		 */
 		public final void platformPropertiesFromSequence(@NonNull ASN1Sequence seq) {
-			Arrays.asList(seq.toArray()).forEach(
-					element ->
-							this.platformProperty(PlatformPropertiesV2.getInstance(element)));
+			Optional.ofNullable(ASN1Utils.safeGetDefaultElement(seq, null, PlatformPropertiesV2::getInstance))
+					.map(List::of)
+					.orElseGet(() -> Stream.of(seq.toArray()).map(PlatformPropertiesV2::getInstance).toList())
+					.forEach(this::platformProperty);
 		}
 	}
 }

--- a/src/main/java/paccor/tcg/credential/PlatformConfigurationV3.java
+++ b/src/main/java/paccor/tcg/credential/PlatformConfigurationV3.java
@@ -6,8 +6,9 @@ import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.annotation.JsonPropertyDescription;
 import jakarta.validation.constraints.Size;
-import java.util.Arrays;
 import java.util.List;
+import java.util.Optional;
+import java.util.stream.Stream;
 import paccor.json.schema.HardwareManifestSchema;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
@@ -63,12 +64,14 @@ public class PlatformConfigurationV3 extends ASN1Object {
 	private static final int MIN_SEQUENCE_SIZE = 0;
 	private static final int MAX_SEQUENCE_SIZE = 2;
 
-	@JsonProperty(HardwareManifestSchema.COMPONENTS)
+    @JsonFormat(with = JsonFormat.Feature.ACCEPT_SINGLE_VALUE_AS_ARRAY)
+    @JsonProperty(HardwareManifestSchema.COMPONENTS)
 	@JsonPropertyDescription("Platform components represented as trait collections.")
 	@Singular
     @Size(min = 1)
 	private final List<TraitMap> platformComponents; // optional, tagged 0
-	@JsonProperty(HardwareManifestSchema.PROPERTIES)
+    @JsonFormat(with = JsonFormat.Feature.ACCEPT_SINGLE_VALUE_AS_ARRAY)
+    @JsonProperty(HardwareManifestSchema.PROPERTIES)
 	@JsonPropertyDescription("Platform properties associated with the configuration.")
 	@Singular
     @Size(min = 1)
@@ -136,18 +139,20 @@ public class PlatformConfigurationV3 extends ASN1Object {
          * @param seq ASN1Sequence
          */
         public final void platformComponentsFromSequence(@NonNull ASN1Sequence seq) {
-            Arrays.asList(seq.toArray()).forEach(
-                    element ->
-                            this.platformComponent(TraitMap.getInstance(element)));
+            Optional.ofNullable(ASN1Utils.safeGetDefaultElement(seq, null, TraitMap::getInstance))
+                    .map(List::of)
+                    .orElseGet(() -> Stream.of(seq.toArray()).map(TraitMap::getInstance).toList())
+                    .forEach(this::platformComponent);
         }
         /**
          * Reads elements of the given sequence as PlatformPropertiesV2 and adds them to the builder.
          * @param seq ASN1Sequence
          */
         public final void platformPropertiesFromSequence(@NonNull ASN1Sequence seq) {
-            Arrays.asList(seq.toArray()).forEach(
-                    element ->
-                            this.platformProperty(PlatformPropertiesV2.getInstance(element)));
+            Optional.ofNullable(ASN1Utils.safeGetDefaultElement(seq, null, PlatformPropertiesV2::getInstance))
+                    .map(List::of)
+                    .orElseGet(() -> Stream.of(seq.toArray()).map(PlatformPropertiesV2::getInstance).toList())
+                    .forEach(this::platformProperty);
         }
     }
 }

--- a/src/main/java/paccor/validator/ComponentValidator.java
+++ b/src/main/java/paccor/validator/ComponentValidator.java
@@ -168,16 +168,17 @@ public final class ComponentValidator {
         return -1;
     }
 
-    private record ComponentKey(String registryOid, String classValueHex, String manufacturer, String model) {
+    private record ComponentKey(String registryOid, String classValueHex, String manufacturer, String model, String serial) {
         static ComponentKey from(TraitMap traits) {
             String registry = componentRegistryOid(traits);
             String classValue = componentClassValueHex(traits);
             String manufacturer = componentManufacturer(traits);
             String model = componentModel(traits);
+            String serial = componentSerial(traits);
             if (registry == null || classValue == null || manufacturer == null || model == null) {
                 return null;
             }
-            return new ComponentKey(registry, classValue, manufacturer, model);
+            return new ComponentKey(registry, classValue, manufacturer, model, serial);
         }
     }
 
@@ -197,6 +198,12 @@ public final class ComponentValidator {
     private static String componentModel(TraitMap traits) {
         return TraitCollection.from(traits)
                 .firstStringWithCategory(TCGObjectIdentifier.tcgTrCatComponentModel)
+                .orElse(null);
+    }
+
+    private static String componentSerial(TraitMap traits) {
+        return TraitCollection.from(traits)
+                .firstStringWithCategory(TCGObjectIdentifier.tcgTrCatComponentSerial)
                 .orElse(null);
     }
 


### PR DESCRIPTION
paccor validate was not differentiating on serial number in delta certificates. It should now see those individual components.

I made hardware manifest parsing allow single objects for COMPONENTS and PROPERTIES.

Certificate parsing will look for a PEM block within the file to decide whether to give the data to a PEM parser convert from DER first. This should look past the print out OpenSSL is including in PEM files it creates.