### PR TITLE
Several inconsistencies with Traits

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -6,7 +6,7 @@ plugins {
     alias(libs.plugins.ospackage) // see gradle/libs.versions.toml
 }
 
-version = "2.0r5"
+version = "2.0r6"
 
 // Build is split up into multiple files.
 

--- a/docs/doc-tools/src/main/java/json/SchemaUtils.java
+++ b/docs/doc-tools/src/main/java/json/SchemaUtils.java
@@ -516,7 +516,7 @@ public class SchemaUtils {
                 "Generic DER-encoded octet string given meaning by context information. paccor attempts to resolve the data to a specific type using trait metadata."));
 
         for (String alias : TRAIT_VALUE_ALIASES) {
-            properties.set(alias, createRefWithDescription(context, TraitId.getTraitClassByAlias(alias), "Click the reference to see JSON format. It should be similar to the spec."));
+            properties.set(alias, createRefWithDescription(context, TraitId.getTraitClassByAlias(alias), "JSON format follows the referenced schema. It should be similar to the spec."));
         }
 
         ArrayNode required = schema.putArray(getTag(context, SchemaKeyword.TAG_REQUIRED));

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -260,6 +260,8 @@ An example of the full command: `paccor certgen -x "$extsettings" -c "$component
 -P "$pcsigncert" -N "$serialnumber" -b "$dateNotBefore" -a "$dateNotAfter" --sig-profile "$paccor_sigalg"
 -f "$tbsout" --finalize`
 
+Example with variables substituted: `paccor certgen -x /opt/paccor/scripts/pc_testgen/extensions.json -c /opt/paccor/scripts/pc_testgen/localhost-componentlist.json -e /opt/paccor/scripts/pc_testgen/ek.cer -p /opt/paccor/scripts/pc_testgen/localhost-policyreference.json -P /opt/paccor/scripts/pc_testgen/PCTestCA.example.com.pem -N 0001 -b 20180101 -a 20380101 --sig-profile rsa-sha256 -f /opt/paccor/scripts/pc_testgen/tbs.json --finalize`
+
 Inputs:
 
 - EK certificate
@@ -287,13 +289,15 @@ material is accessed and used.
 
 Example: `paccor assemble --in "$tbsout" -k "$sigkey" -P "$pcsigncert" -f "$pccert" --pem`
 
+Example with variables substituted: `paccor assemble --in /opt/paccor/scripts/pc_testgen/tbs.json -k /opt/paccor/scripts/pc_testgen/private.pem -P /opt/paccor/scripts/pc_testgen/PCTestCA.example.com.pem -f /opt/paccor/scripts/pc_testgen/platform_cert.20260715133924.cer --pem`
+
 Inputs:
 
 - TBS data
 - signing method to include local key, PKCS#11 information, or remote access information
 - issuer certificate
 - where to save the signed certificate
-- encoding choice for the signed certificate, DER or PEM
+- encoding choice for the signed certificate, DER (by default) or specify PEM encoding
 
 If the certificate signature and generation succeeded, it will be written to the location specified. It can be viewed
 and validated immediately.
@@ -303,6 +307,8 @@ and validated immediately.
 The last step is to validate the generated platform certificate.
 
 Example: `paccor validate -P "$pcsigncert" -X "$pccert" -c "$componentlist"`
+
+Example with variables substituted: `paccor validate -P /opt/paccor/scripts/pc_testgen/PCTestCA.example.com.pem -X /opt/paccor/scripts/pc_testgen/platform_cert.20260715133924.cer -c /opt/paccor/scripts/pc_testgen/localhost-componentlist.json`
 
 Things checked:
 

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -3,15 +3,15 @@
 
 [versions]
 bouncycastle = "1.84"
-commons_compress = "1.27.1"
-jackson = "3.1.1"
-jackson_annotations = "2.21"
+commons_compress = "1.28.0"
+jackson = "3.2.1"
+jackson_annotations = "2.22"
 jakarta_validation = "3.1.1"
 jsonschema = "5.0.0"
-junit = "6.0.2"
-lombok = "1.18.44"
-mockito = "5.21.0"
-ospackage = "12.2.0"
+junit = "6.1.1"
+lombok = "1.18.46"
+mockito = "5.23.0"
+ospackage = "12.3.0"
 picocli = "4.7.7"
 redline = "1.2.10"
 

--- a/src/main/java/paccor/cert/TbsEncoder.java
+++ b/src/main/java/paccor/cert/TbsEncoder.java
@@ -243,6 +243,8 @@ public class TbsEncoder {
         addAttribute(attributes, TCGObjectIdentifier.tcgAtPlatformConfigUri, uri);
         addAttribute(attributes, TCGObjectIdentifier.tcgAtPreviousPlatformCertificates, platformInfo.getPreviousPlatformCertificates());
         addAttribute(attributes, TCGObjectIdentifier.tcgAtCryptographicAnchors, platformInfo.getCryptographicAnchors());
+        addAttribute(attributes, TCGObjectIdentifier.tcgAtPlatformOwnership, platformInfo.getPlatformOwnership());
+        addAttribute(attributes, TCGObjectIdentifier.tcgAtManufacturingAssertions, platformInfo.getManufacturingAssertions());
         return attributes;
     }
 

--- a/src/main/java/paccor/cert/TbsEncoder.java
+++ b/src/main/java/paccor/cert/TbsEncoder.java
@@ -228,7 +228,11 @@ public class TbsEncoder {
             addAttribute(attributes, TCGObjectIdentifier.tcgAtTcgCredentialType, new TCGCredentialType(credentialType));
         }
         if (!CertTypeResolver.isDeltaOid(credentialType)) {
-            addAttribute(attributes, TCGObjectIdentifier.tcgAtTbbSecurityAssertions, platformInfo.getTbbSecurityAssertions());
+            if (profile.specVersion() == CertSpecVersion.V2_0 && platformInfo.getTbbSecurityAssertions() != null) {
+                addAttribute(attributes, TCGObjectIdentifier.tcgAtTbbSecurityAssertionsV3, platformInfo.getTbbSecurityAssertions().toTraitMap());
+            } else {
+                addAttribute(attributes, TCGObjectIdentifier.tcgAtTbbSecurityAssertions, platformInfo.getTbbSecurityAssertions());
+            }
             addAttribute(attributes, TCGObjectIdentifier.tcgAtTcgPlatformSpecification, platformInfo.getTcgPlatformSpecification());
         }
         addAttribute(attributes, TCGObjectIdentifier.tcgAtTcgCredentialSpecification, platformInfo.getTcgCredentialSpecification());

--- a/src/main/java/paccor/cert/TbsFinalizer.java
+++ b/src/main/java/paccor/cert/TbsFinalizer.java
@@ -18,10 +18,14 @@ import org.bouncycastle.asn1.x509.ExtendedKeyUsage;
 import org.bouncycastle.asn1.x509.KeyPurposeId;
 import org.bouncycastle.util.encoders.Base64;
 import paccor.tcg.credential.TBBSecurityAssertions;
-import paccor.tcg.credential.Trait;
 import paccor.tcg.credential.TraitMap;
+import paccor.tcg.credential.TCGObjectIdentifier;
+import paccor.tcg.credential.ComponentIdentifierV11Trait;
+import paccor.tcg.credential.PlatformPropertiesV2;
+import java.util.HashSet;
+import java.util.Optional;
 import java.util.Set;
-import java.util.stream.Collectors;
+import java.util.stream.IntStream;
 
 @Builder
 public record TbsFinalizer(String tbsB64, String shaHex) {
@@ -30,9 +34,8 @@ public record TbsFinalizer(String tbsB64, String shaHex) {
         issues.addAll(checkSpecification(profile, pi));
         issues.addAll(checkAcFields(pi));
         validateTbbSecurityAssertions(profile.specVersion(), pi, issues);
-        mustHaveExtension(pi.getExtensions(), Extension.authorityKeyIdentifier, "Authority Key Identifier", issues);
-        mustHaveExtension(pi.getExtensions(), Extension.certificatePolicies, "Certificate Policies", issues);
-        mustHaveExtension(pi.getExtensions(), Extension.subjectAlternativeName, "Subject Alternative Name", issues);
+        validateV2Traits(profile.specVersion(), pi, issues);
+        mustHaveMandatoryExtensions(pi, issues);
         return issues;
     }
 
@@ -41,14 +44,19 @@ public record TbsFinalizer(String tbsB64, String shaHex) {
         issues.addAll(checkSpecification(profile, pi));
         issues.addAll(checkPkcFields(pi));
         validateTbbSecurityAssertions(profile.specVersion(), pi, issues);
-        mustHaveExtension(pi.getExtensions(), Extension.authorityKeyIdentifier, "Authority Key Identifier", issues);
-        mustHaveExtension(pi.getExtensions(), Extension.certificatePolicies, "Certificate Policies", issues);
-        mustHaveExtension(pi.getExtensions(), Extension.subjectAlternativeName, "Subject Alternative Name", issues);
+        validateV2Traits(profile.specVersion(), pi, issues);
+        mustHaveMandatoryExtensions(pi, issues);
         mustHaveExtension(pi.getExtensions(), Extension.subjectKeyIdentifier, "Subject Key Identifier", issues);
         mustHaveExtension(pi.getExtensions(), Extension.basicConstraints, "Basic Constraints", issues, true);
         mustHavePkcExtendedKeyUsage(profile, pi, issues);
         validateBasicConstraints(pi.getExtensions(), issues);
         return issues;
+    }
+
+    private static void mustHaveMandatoryExtensions(PlatformCertificateInformationModel pi, List<String> issues) {
+        mustHaveExtension(pi.getExtensions(), Extension.authorityKeyIdentifier, "Authority Key Identifier", issues);
+        mustHaveExtension(pi.getExtensions(), Extension.certificatePolicies, "Certificate Policies", issues);
+        mustHaveExtension(pi.getExtensions(), Extension.subjectAlternativeName, "Subject Alternative Name", issues);
     }
 
     private static List<String> checkCommonFields(PlatformCertificateInformationModel pi) {
@@ -193,40 +201,91 @@ public record TbsFinalizer(String tbsB64, String shaHex) {
             CertSpecVersion specVersion,
             PlatformCertificateInformationModel pi,
             List<String> issues) {
-        TBBSecurityAssertions assertions = pi.getTbbSecurityAssertions();
-        if (assertions == null) return;
+        Optional.ofNullable(pi.getTbbSecurityAssertions())
+                .filter(_ -> specVersion == CertSpecVersion.V2_0)
+                .map(TBBSecurityAssertions::getTraits)
+                .ifPresent(traits -> TraitMap.validateTraitMap(traits, "TBBSecurityAssertions", TBBSecurityAssertions.ALLOWED_TRAIT_TYPES, null, issues));
+    }
+
+    private static void validateV2Traits(CertSpecVersion specVersion, PlatformCertificateInformationModel pi, List<String> issues) {
         if (specVersion == CertSpecVersion.V2_0) {
-            TraitMap traits = assertions.getTraits();
-            validateTraitMap(traits, "TBBSecurityAssertions", TBBSecurityAssertions.ALLOWED_TRAIT_TYPES, null, issues);
+            validatePlatformIdentifier(pi, issues);
+            validateComponents(pi, issues);
+            validatePlatformOwnership(pi, issues);
         }
     }
 
-    private static void validateTraitMap(
-            TraitMap traits,
+    private static void validatePlatformIdentifier(PlatformCertificateInformationModel pi, List<String> issues) {
+        Optional.ofNullable(pi.getPlatformTraits())
+                .filter(traits -> !traits.isEmpty())
+                .ifPresentOrElse(
+                        traits -> TraitMap.validateTraitMap(traits, "PlatformIdentifier", null,
+                                Set.of(TCGObjectIdentifier.tcgTrCatPlatformManufacturer,
+                                        TCGObjectIdentifier.tcgTrCatPlatformModel,
+                                        TCGObjectIdentifier.tcgTrCatPlatformVersion),
+                                issues),
+                        () -> issues.add("Subject Alternative Name must contain a PlatformIdentifier sequence with traits.")
+                );
+    }
+
+    private static void validateComponents(PlatformCertificateInformationModel pi, List<String> issues) {
+        Optional.ofNullable(pi.getPlatformConfiguration()).ifPresent(pc -> {
+            boolean isDelta = Boolean.TRUE.equals(pi.getIsDelta());
+            validateComponentTraits(pc.getPlatformComponents(), isDelta, issues);
+            if (isDelta) {
+                validatePropertyStatus(pc.getPlatformProperties(), issues);
+            }
+        });
+    }
+
+    private static void validateComponentTraits(List<TraitMap> components, boolean isDelta, List<String> issues) {
+        if (components == null) return;
+        Set<ASN1ObjectIdentifier> requiredBase = Set.of(
+                TCGObjectIdentifier.tcgTrCatComponentClass,
+                TCGObjectIdentifier.tcgTrCatComponentManufacturer,
+                TCGObjectIdentifier.tcgTrCatComponentModel
+        );
+        IntStream.range(0, components.size()).forEach(i -> {
+            TraitMap component = components.get(i);
+            String context = "Component[" + i + "]";
+            if (component.containsKey(ComponentIdentifierV11Trait.class)) {
+                validateV11Component(component, context, issues);
+            } else {
+                validateV20Component(component, context, isDelta, requiredBase, issues);
+            }
+        });
+    }
+
+    private static void validateV11Component(TraitMap component, String context, List<String> issues) {
+        if (component.size() > 1) {
+            issues.add(context + " containing ComponentIdentifierV11Trait SHALL NOT contain any other trait.");
+        }
+    }
+
+    private static void validateV20Component(
+            TraitMap component,
             String context,
-            Set<Class<? extends Trait<?, ?>>> allowedTypes,
-            Set<ASN1ObjectIdentifier> requiredCategories,
+            boolean isDelta,
+            Set<ASN1ObjectIdentifier> requiredBase,
             List<String> issues) {
-        if (traits == null || traits.isEmpty()) return;
-
-        if (allowedTypes != null) {
-            for (Class<? extends Trait<?, ?>> type : traits.keySet()) {
-                if (!allowedTypes.contains(type)) {
-                    issues.add(context + " contains unsupported trait type: " + type.getSimpleName());
-                }
-            }
+        Set<ASN1ObjectIdentifier> required = new HashSet<>(requiredBase);
+        if (isDelta) {
+            required.add(TCGObjectIdentifier.tcgTrCatComponentStatus);
         }
+        TraitMap.validateTraitMap(component, context, null, required, issues);
+    }
 
-        if (requiredCategories != null) {
-            Set<ASN1ObjectIdentifier> presentCategories = traits.flattenTraits().stream()
-                    .map(Trait::getTraitCategory)
-                    .collect(Collectors.toSet());
-            for (ASN1ObjectIdentifier required : requiredCategories) {
-                if (!presentCategories.contains(required)) {
-                    issues.add(context + " is missing required trait category: " + required.getId());
-                }
-            }
-        }
+    private static void validatePropertyStatus(List<PlatformPropertiesV2> properties, List<String> issues) {
+        if (properties == null) return;
+        IntStream.range(0, properties.size())
+                .filter(i -> properties.get(i).getStatus() == null)
+                .forEach(i -> issues.add("Property[" + i + "] in Delta Platform Certificate SHALL contain the status field."));
+    }
+
+    private static void validatePlatformOwnership(PlatformCertificateInformationModel pi, List<String> issues) {
+        Optional.ofNullable(pi.getPlatformOwnership())
+                .filter(traits -> !traits.isEmpty())
+                .ifPresent(traits -> TraitMap.validateTraitMap(traits, "PlatformOwnership", null, Set.of(TCGObjectIdentifier.tcgTrCatPlatformOwnership), issues));
     }
 
     /**

--- a/src/main/java/paccor/cert/TbsFinalizer.java
+++ b/src/main/java/paccor/cert/TbsFinalizer.java
@@ -17,6 +17,11 @@ import org.bouncycastle.asn1.x509.Extension;
 import org.bouncycastle.asn1.x509.ExtendedKeyUsage;
 import org.bouncycastle.asn1.x509.KeyPurposeId;
 import org.bouncycastle.util.encoders.Base64;
+import paccor.tcg.credential.TBBSecurityAssertions;
+import paccor.tcg.credential.Trait;
+import paccor.tcg.credential.TraitMap;
+import java.util.Set;
+import java.util.stream.Collectors;
 
 @Builder
 public record TbsFinalizer(String tbsB64, String shaHex) {
@@ -24,6 +29,7 @@ public record TbsFinalizer(String tbsB64, String shaHex) {
         List<String> issues = checkCommonFields(pi);
         issues.addAll(checkSpecification(profile, pi));
         issues.addAll(checkAcFields(pi));
+        validateTbbSecurityAssertions(profile.specVersion(), pi, issues);
         mustHaveExtension(pi.getExtensions(), Extension.authorityKeyIdentifier, "Authority Key Identifier", issues);
         mustHaveExtension(pi.getExtensions(), Extension.certificatePolicies, "Certificate Policies", issues);
         mustHaveExtension(pi.getExtensions(), Extension.subjectAlternativeName, "Subject Alternative Name", issues);
@@ -34,6 +40,7 @@ public record TbsFinalizer(String tbsB64, String shaHex) {
         List<String> issues = checkCommonFields(pi);
         issues.addAll(checkSpecification(profile, pi));
         issues.addAll(checkPkcFields(pi));
+        validateTbbSecurityAssertions(profile.specVersion(), pi, issues);
         mustHaveExtension(pi.getExtensions(), Extension.authorityKeyIdentifier, "Authority Key Identifier", issues);
         mustHaveExtension(pi.getExtensions(), Extension.certificatePolicies, "Certificate Policies", issues);
         mustHaveExtension(pi.getExtensions(), Extension.subjectAlternativeName, "Subject Alternative Name", issues);
@@ -180,6 +187,46 @@ public record TbsFinalizer(String tbsB64, String shaHex) {
             return CertTypeResolver.toOid(CertKind.PKC, CertType.BASE);
         }
         return Extension.extendedKeyUsage;
+    }
+
+    private static void validateTbbSecurityAssertions(
+            CertSpecVersion specVersion,
+            PlatformCertificateInformationModel pi,
+            List<String> issues) {
+        TBBSecurityAssertions assertions = pi.getTbbSecurityAssertions();
+        if (assertions == null) return;
+        if (specVersion == CertSpecVersion.V2_0) {
+            TraitMap traits = assertions.getTraits();
+            validateTraitMap(traits, "TBBSecurityAssertions", TBBSecurityAssertions.ALLOWED_TRAIT_TYPES, null, issues);
+        }
+    }
+
+    private static void validateTraitMap(
+            TraitMap traits,
+            String context,
+            Set<Class<? extends Trait<?, ?>>> allowedTypes,
+            Set<ASN1ObjectIdentifier> requiredCategories,
+            List<String> issues) {
+        if (traits == null || traits.isEmpty()) return;
+
+        if (allowedTypes != null) {
+            for (Class<? extends Trait<?, ?>> type : traits.keySet()) {
+                if (!allowedTypes.contains(type)) {
+                    issues.add(context + " contains unsupported trait type: " + type.getSimpleName());
+                }
+            }
+        }
+
+        if (requiredCategories != null) {
+            Set<ASN1ObjectIdentifier> presentCategories = traits.flattenTraits().stream()
+                    .map(Trait::getTraitCategory)
+                    .collect(Collectors.toSet());
+            for (ASN1ObjectIdentifier required : requiredCategories) {
+                if (!presentCategories.contains(required)) {
+                    issues.add(context + " is missing required trait category: " + required.getId());
+                }
+            }
+        }
     }
 
     /**

--- a/src/main/java/paccor/cli/ViewCmd.java
+++ b/src/main/java/paccor/cli/ViewCmd.java
@@ -92,6 +92,12 @@ public class ViewCmd implements Callable<Integer>, HasCommonOptions {
         TraitMap anchors = info.getCryptographicAnchors();
         println("Cryptographic Anchors: " + countTraits(anchors));
 
+        TraitMap ownership = info.getPlatformOwnership();
+        println("Platform Ownership: " + countTraits(ownership));
+
+        TraitMap manufacturingAssertions = info.getManufacturingAssertions();
+        println("Manufacturing Assertions: " + countTraits(manufacturingAssertions));
+
         return ClientExitCodes.SUCCESS.code();
     }
 

--- a/src/main/java/paccor/json/AttributesJsonHelper.java
+++ b/src/main/java/paccor/json/AttributesJsonHelper.java
@@ -56,6 +56,10 @@ public record AttributesJsonHelper(
         @JsonProperty(AttributesSchema.CRYPTOGRAPHIC_ANCHORS)
         @JsonDeserialize(using = CryptographicAnchorsDeserializer.class)
         TraitMap cryptographicAnchors,
+        @JsonProperty(AttributesSchema.PLATFORM_OWNERSHIP)
+        TraitMap platformOwnership,
+        @JsonProperty(AttributesSchema.MANUFACTURING_ASSERTIONS)
+        TraitMap manufacturingAssertions,
         // uncommon fields, V1.0 fields
         @JsonProperty(AttributesSchema.TCPA_SPEC_VERSION)
         TCPASpecVersion tCPASpecVersion,

--- a/src/main/java/paccor/json/CertificateBackedTraitMapDeserializer.java
+++ b/src/main/java/paccor/json/CertificateBackedTraitMapDeserializer.java
@@ -6,6 +6,8 @@ import java.io.File;
 import java.io.IOException;
 import java.util.ArrayList;
 import java.util.List;
+import java.util.Optional;
+import java.util.stream.Collectors;
 import paccor.model.CertificateReference;
 import paccor.tcg.credential.Trait;
 import paccor.tcg.credential.TraitMap;
@@ -35,32 +37,36 @@ abstract class CertificateBackedTraitMapDeserializer extends ValueDeserializer<T
                 continue;
             }
 
-            JsonNode fileNode = JsonUtils.get(node, false, "file").orElse(null);
-            if (fileNode != null && fileNode.isString() && !fileNode.asString().isBlank()) {
-                addFileBackedTrait(builder, referenceObjects, fileNode.asString().trim(), node);
-                continue;
-            }
+            Optional<String> filePath = JsonUtils.get(node, false, "file")
+                    .flatMap(JsonUtils::onlyNotBlankString)
+                    .map(JsonNode::asString)
+                    .map(String::trim);
 
-            Class<? extends Trait<?, ?>> traitClass = TraitDeserializer.resolveTraitClass(context, node);
-            Trait<?, ?> trait = Trait.getInstance(node, traitClass);
-            if (trait != null) {
-                builder.trait(trait);
+            if (filePath.isPresent()) {
+                addFileBackedTrait(builder, referenceObjects, filePath.get(), node);
+            } else {
+                Class<? extends Trait<?, ?>> traitClass = TraitDeserializer.resolveTraitClass(context, node);
+                Optional.ofNullable(Trait.getInstance(node, traitClass))
+                        .ifPresent(builder::trait);
             }
         }
 
         return buildResolvedCollection(builder, referenceObjects);
     }
 
-    private static List<JsonNode> elements(JsonNode root) {
-        JsonNode traitsNode = root;
-        if (root.isObject()) {
-            traitsNode = JsonUtils.get(root, false, "traits").orElse(root);
-        }
+    @Override
+    public TraitMap getNullValue(DeserializationContext ctxt) {
+        return buildResolvedCollection(TraitMap.builder(), new ArrayList<>());
+    }
 
-        if (traitsNode != null && traitsNode.isArray()) {
-            return JsonUtils.asStream(traitsNode.spliterator()).toList();
-        }
-        return List.of(traitsNode);
+    private static List<JsonNode> elements(JsonNode root) {
+        JsonNode traitsNode = root.isObject()
+                ? JsonUtils.get(root, false, "traits").orElse(root)
+                : root;
+
+        return traitsNode.isArray()
+                ? JsonUtils.asStream(traitsNode.spliterator()).collect(Collectors.toList())
+                : List.of(traitsNode);
     }
 
     private void addFileBackedTrait(

--- a/src/main/java/paccor/json/ComponentAddressDeserializer.java
+++ b/src/main/java/paccor/json/ComponentAddressDeserializer.java
@@ -4,9 +4,8 @@ import java.io.IOException;
 import java.util.Optional;
 import paccor.json.schema.ComponentSchema;
 import paccor.json.schema.JsonSchemaValue;
-import org.bouncycastle.asn1.ASN1ObjectIdentifier;
-import org.bouncycastle.asn1.DERUTF8String;
 import paccor.normalization.HexNormalizer;
+import paccor.tcg.credential.ASN1Utils;
 import paccor.tcg.credential.ComponentAddress;
 import tools.jackson.core.JacksonException;
 import tools.jackson.core.JsonParser;
@@ -40,34 +39,23 @@ public class ComponentAddressDeserializer extends ValueDeserializer<ComponentAdd
     }
 
     private ComponentAddress handleTwoElements(JsonNode node, boolean caseSens) {
-        ComponentAddress.ComponentAddressBuilder address = ComponentAddress.builder();
-        if (JsonUtils.has(node, caseSens,
-                ComponentSchema.AddressField.ADDRESS_TYPE_FIELD,
-                ComponentSchema.AddressField.ADDRESS_VALUE_FIELD)) {
-            Optional<JsonNode> typeOpt = JsonUtils.get(node, caseSens, ComponentSchema.AddressField.ADDRESS_TYPE_FIELD);
-            Optional<JsonNode> valueOpt = JsonUtils.get(node, caseSens, ComponentSchema.AddressField.ADDRESS_VALUE_FIELD);
-
-            typeOpt.ifPresent(typeNode ->
-                    valueOpt.ifPresent(valueNode -> {
-                        ComponentSchema.AddressTypeValue typeValue =
-                                JsonSchemaValue.lookup(typeNode.asString(), ComponentSchema.AddressTypeValue.class);
-                        address.addressType(typeValue.oid());
-                        address.addressValue(new DERUTF8String(HexNormalizer.normalizeMac(valueNode.asString())));
-                    }));
-        }
-        return address.build();
+        return JsonUtils.get(node, caseSens, ComponentSchema.AddressField.ADDRESS_TYPE_FIELD)
+                .flatMap(typeNode -> JsonUtils.get(node, caseSens, ComponentSchema.AddressField.ADDRESS_VALUE_FIELD)
+                        .map(valueNode -> ComponentAddress.builder()
+                                .addressType(JsonSchemaValue.lookup(typeNode.asString(), ComponentSchema.AddressTypeValue.class).oid())
+                                .addressValue(ASN1Utils.getUTF8String(HexNormalizer.normalizeMac(valueNode.asString())))
+                                .build()))
+                .orElseGet(() -> ComponentAddress.builder().build());
     }
 
     private ComponentAddress handleOneElement(JsonNode node, boolean caseSens) {
-        ComponentAddress.ComponentAddressBuilder address = ComponentAddress.builder();
-        final String type = node.propertyNames().iterator().next();
-        final String value = node.get(type).asString();
+        String type = node.propertyNames().iterator().next();
+        String value = node.get(type).asString();
 
         ComponentSchema.AddressTypeValue typeValue = JsonSchemaValue.lookup(type, ComponentSchema.AddressTypeValue.class);
-        address.addressType(new ASN1ObjectIdentifier(typeValue.getValue()));
-
-        final String filtered = HexNormalizer.normalizeMac(value);
-        address.addressValue(new DERUTF8String(filtered));
-        return address.build();
+        return ComponentAddress.builder()
+                .addressType(ASN1Utils.getOID(typeValue.getValue()))
+                .addressValue(ASN1Utils.getUTF8String(HexNormalizer.normalizeMac(value)))
+                .build();
     }
 }

--- a/src/main/java/paccor/json/HardwareManifestJsonHelper.java
+++ b/src/main/java/paccor/json/HardwareManifestJsonHelper.java
@@ -5,13 +5,11 @@ import com.fasterxml.jackson.annotation.JsonClassDescription;
 import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 import com.fasterxml.jackson.annotation.JsonPropertyDescription;
 import java.io.File;
-import java.util.ArrayList;
 import java.util.List;
+import java.util.Objects;
 import java.util.Optional;
-import lombok.AllArgsConstructor;
+import java.util.stream.Collectors;
 import lombok.Builder;
-import lombok.Data;
-import lombok.NoArgsConstructor;
 import lombok.extern.jackson.Jacksonized;
 import paccor.json.schema.HardwareManifestSchema;
 import paccor.normalization.ComponentIdentifierV2Converter;
@@ -58,7 +56,7 @@ public record HardwareManifestJsonHelper(
     }
 
     /**
-     * Reads components from JSON file.
+     * Reads components from a JSON file.
      * @param componentsJson file to read
      * @return HardwareManifestJsonHelper with populated data
      */
@@ -138,56 +136,35 @@ public record HardwareManifestJsonHelper(
     }
 
     private static List<TraitMap> readPlatformComponents(JsonNode comps) {
-        List<TraitMap> components = new ArrayList<>();
-        for (JsonNode node : asNodeList(comps)) {
-            TraitMap tm = readTraitMap(node);
-            if (tm != null && !tm.isEmpty()) {
-                components.add(tm);
-            }
-        }
-        return components;
+        return asNodeList(comps).stream()
+                .map(HardwareManifestJsonHelper::readTraitMap)
+                .filter(tm -> tm != null && !tm.isEmpty())
+                .collect(Collectors.toList());
     }
 
     private static TraitMap readTraitMap(JsonNode node) {
-        try {
-            TraitMap tm = ObjectMapperFactory.fromJsonNode(node, TraitMap.class);
-            if (tm != null && !tm.isEmpty()) {
-                return tm;
-            }
-        } catch (Exception ignored) { }
-
-        try {
-            ComponentIdentifierV2 v2 = ObjectMapperFactory.fromJsonNode(node, ComponentIdentifierV2.class);
-            return ComponentIdentifierV2Converter.toTraitMap(v2);
-        } catch (Exception ignored) {
-            return null;
+        TraitMap tm = ObjectMapperFactory.fromJsonNodeSafe(node, TraitMap.class);
+        if (tm != null && !tm.isEmpty()) {
+            return tm;
         }
+
+        ComponentIdentifierV2 v2 = ObjectMapperFactory.fromJsonNodeSafe(node, ComponentIdentifierV2.class);
+        return v2 != null ? ComponentIdentifierV2Converter.toTraitMap(v2) : null;
     }
 
     private static List<PlatformPropertiesV2> readPlatformProperties(JsonNode props) {
-        List<PlatformPropertiesV2> out = new ArrayList<>();
-        for (JsonNode p : asNodeList(props)) {
-            try {
-                PlatformPropertiesV2 prop = ObjectMapperFactory.fromJsonNode(p, PlatformPropertiesV2.class);
-                if (prop != null) {
-                    out.add(prop);
-                }
-            } catch (Exception ignored) { }
-        }
-        return out;
+        return asNodeList(props).stream()
+                .map(p -> ObjectMapperFactory.fromJsonNodeSafe(p, PlatformPropertiesV2.class))
+                .filter(Objects::nonNull)
+                .collect(Collectors.toList());
     }
 
     private static List<JsonNode> asNodeList(JsonNode node) {
-        if (node == null || node.isNull()) {
-            return List.of();
-        }
-        if (node.isArray()) {
-            List<JsonNode> out = new ArrayList<>();
-            for (JsonNode child : node) {
-                out.add(child);
-            }
-            return out;
-        }
-        return List.of(node);
+        return Optional.ofNullable(node)
+                .filter(n -> !n.isNull())
+                .map(n -> n.isArray()
+                        ? JsonUtils.asStream(n.spliterator()).collect(Collectors.toList())
+                        : List.of(n))
+                .orElse(List.of());
     }
 }

--- a/src/main/java/paccor/json/IssuerSerialDeserializer.java
+++ b/src/main/java/paccor/json/IssuerSerialDeserializer.java
@@ -19,24 +19,13 @@ import tools.jackson.databind.ValueDeserializer;
 public class IssuerSerialDeserializer extends ValueDeserializer<IssuerSerial> {
     @Override
     public IssuerSerial deserialize(JsonParser p, DeserializationContext context) throws JacksonException {
-        JsonNode node = context.readTree(p);
-
-        Optional<JsonNode> issuerOpt = JsonUtils.get(node, false, ComponentSchema.IssuerSerialField.ISSUER_FIELD);
-        Optional<JsonNode> serialOpt = JsonUtils.get(node, false, ComponentSchema.IssuerSerialField.SERIAL_FIELD);
-
-        final String issuer = issuerOpt
-                .map(JsonNode::asString)
-                .map(String::trim)
-                .orElse("");
-        final String genericCertSerial = serialOpt
-                .map(JsonNode::asString)
-                .map(String::trim)
-                .orElse("");
-
-        if (!issuer.isEmpty() && !genericCertSerial.isEmpty()) {
-            return new IssuerSerial(new X500Name(issuer), new BigInteger(genericCertSerial));
-        }
-        // Handle other cases or throw an exception if the format is unexpected
-        throw JacksonIOException.construct(new IOException("Unexpected JSON format for IssuerSerial"));
+        return Optional.ofNullable(context.readTree(p))
+                .filter(node -> !node.isNull())
+                .flatMap(node -> JsonUtils.get(node, false, ComponentSchema.IssuerSerialField.ISSUER_FIELD)
+                        .flatMap(JsonUtils::trimmedValueAsText)
+                        .flatMap(issuer -> JsonUtils.get(node, false, ComponentSchema.IssuerSerialField.SERIAL_FIELD)
+                                .flatMap(JsonUtils::trimmedValueAsText)
+                                .map(serial -> new IssuerSerial(new X500Name(issuer), new BigInteger(serial)))))
+                .orElseThrow(() -> JacksonIOException.construct(new IOException("Unexpected JSON format for IssuerSerial")));
     }
 }

--- a/src/main/java/paccor/json/JacksonAsn1Module.java
+++ b/src/main/java/paccor/json/JacksonAsn1Module.java
@@ -23,6 +23,7 @@ import paccor.tcg.credential.ComponentAddress;
 import paccor.tcg.credential.TCGCredentialType;
 import paccor.tcg.credential.TCGPlatformSpecification;
 import paccor.tcg.credential.Trait;
+import paccor.tcg.credential.TraitCollection;
 import paccor.tcg.credential.TraitMap;
 import tools.jackson.databind.module.SimpleModule;
 
@@ -54,6 +55,7 @@ public class JacksonAsn1Module extends SimpleModule {
 
         addDeserializer(ComponentAddress.class, new ComponentAddressDeserializer());
         addDeserializer(Trait.class, new TraitDeserializer());
+        addDeserializer(TraitCollection.class, new TraitCollectionDeserializer());
         addDeserializer(TraitMap.class, new TraitMapDeserializer());
     }
 }

--- a/src/main/java/paccor/json/JsonUtils.java
+++ b/src/main/java/paccor/json/JsonUtils.java
@@ -91,8 +91,24 @@ public class JsonUtils {
      *         Otherwise, an empty {@code Optional}
      */
     public static final Optional<String> trimmedIfText(JsonNode node) {
-        return Optional.of(node)
+        return Optional.ofNullable(node)
                 .filter(JsonNode::isString)
+                .map(JsonNode::asString)
+                .filter(s -> !s.isBlank())
+                .map(String::trim);
+    }
+
+    /**
+     * Processes a given {@code JsonNode} to return an {@code Optional<String>} that contains
+     * the trimmed text value if the node is a value node (string, number, boolean, etc.) and non-blank.
+     *
+     * @param node the {@code JsonNode} to process
+     * @return If the node is a value node and non-blank, an {@code Optional<String>} containing the trimmed text value;
+     *         Otherwise, an empty {@code Optional}
+     */
+    public static final Optional<String> trimmedValueAsText(JsonNode node) {
+        return Optional.ofNullable(node)
+                .filter(n -> !n.isNull() && n.isValueNode())
                 .map(JsonNode::asString)
                 .filter(s -> !s.isBlank())
                 .map(String::trim);

--- a/src/main/java/paccor/json/ObjectMapperFactory.java
+++ b/src/main/java/paccor/json/ObjectMapperFactory.java
@@ -31,6 +31,14 @@ public final class ObjectMapperFactory {
         return get().convertValue(node, type);
     }
 
+    public static final <T> T fromJsonNodeSafe(JsonNode node, Class<T> type) {
+        try {
+            return fromJsonNode(node, type);
+        } catch (Exception ignored) {
+            return null;
+        }
+    }
+
     public static final <T> T fromJson(String json, Class<T> type) throws JsonException {
         return withOrWithoutModule(om -> {
             try {

--- a/src/main/java/paccor/json/TraitCollectionDeserializer.java
+++ b/src/main/java/paccor/json/TraitCollectionDeserializer.java
@@ -1,0 +1,45 @@
+package paccor.json;
+
+import java.util.Objects;
+import java.util.Optional;
+import java.util.stream.Collectors;
+import java.util.stream.StreamSupport;
+import paccor.tcg.credential.Trait;
+import paccor.tcg.credential.TraitCollection;
+import paccor.tcg.credential.TraitMap;
+import tools.jackson.core.JacksonException;
+import tools.jackson.core.JsonParser;
+import tools.jackson.databind.DeserializationContext;
+import tools.jackson.databind.JsonNode;
+import tools.jackson.databind.ValueDeserializer;
+
+public class TraitCollectionDeserializer extends ValueDeserializer<TraitCollection> {
+    @Override
+    public TraitCollection deserialize(JsonParser p, DeserializationContext context) throws JacksonException {
+        return Optional.ofNullable(context.readTree(p))
+                .filter(node -> !node.isNull())
+                .map(node -> node.isArray() ? deserializeArray(node, context) : deserializeObject(node))
+                .orElseGet(TraitCollection::empty);
+    }
+
+    @Override
+    public TraitCollection getNullValue(DeserializationContext ctxt) {
+        return TraitCollection.empty();
+    }
+
+    private static TraitCollection deserializeArray(JsonNode node, DeserializationContext context) {
+        return StreamSupport.stream(node.spliterator(), false)
+                .map(traitNode -> readTrait(context, traitNode))
+                .filter(Objects::nonNull)
+                .collect(Collectors.collectingAndThen(Collectors.toList(), TraitCollection::new));
+    }
+
+    private static TraitCollection deserializeObject(JsonNode node) {
+        // Fallback to TraitMapDeserializer if it's an object (might have "traits" field or be legacy)
+        return TraitCollection.from(ObjectMapperFactory.fromJsonNodeSafe(node, TraitMap.class));
+    }
+
+    private static Trait<?, ?> readTrait(DeserializationContext context, JsonNode traitNode) {
+        return Trait.getInstance(traitNode, TraitDeserializer.resolveTraitClass(context, traitNode));
+    }
+}

--- a/src/main/java/paccor/json/TraitDeserializer.java
+++ b/src/main/java/paccor/json/TraitDeserializer.java
@@ -36,31 +36,14 @@ public class TraitDeserializer extends ValueDeserializer<Trait<?, ?>>  {
      *         Otherwise, the default {@code ASN1ObjectTrait.class}.
      */
     public static final Class<? extends Trait<?, ?>> resolveTraitClass(DeserializationContext context, JsonNode traitNode) {
-        Optional<String> traitIdOid = extractOid(context, traitNode, "traitId");
-        Optional<String> traitCategoryOid = extractOid(context, traitNode, "traitCategory");
-
-        // 1. Try to resolve by traitId first
-        Class<? extends Trait<?, ?>> resultById = ASN1ObjectTrait.class;
-        if (traitIdOid.isPresent()) {
-            resultById = TraitId.getTraitClassForId(traitIdOid.get());
-        }
-        if (resultById != ASN1ObjectTrait.class) {
-            return resultById;
-        }
-
-        // 2. Resolve by Alias (e.g., "status", "booleanValue", "utf8")
-        Class<? extends Trait<?, ?>> resultByAlias = resolveByAlias(traitNode);
-        if (resultByAlias != ASN1ObjectTrait.class) {
-            return resultByAlias;
-        }
-
-        // 3. Try to resolve by traitCategory
-        Class<? extends Trait<?, ?>> resultByCat = ASN1ObjectTrait.class;
-        if (traitCategoryOid.isPresent()) {
-            resultByCat = TraitId.getTraitClassForCategory(traitCategoryOid.get());
-        }
-
-        return resultByCat;
+        return extractOid(context, traitNode, "traitId")
+                .map(TraitId::getTraitClassForId)
+                .filter(clazz -> clazz != ASN1ObjectTrait.class)
+                .or(() -> Optional.of(resolveByAlias(traitNode))
+                        .filter(clazz -> clazz != ASN1ObjectTrait.class))
+                .or(() -> extractOid(context, traitNode, "traitCategory")
+                        .map(TraitId::getTraitClassForCategory))
+                .orElse(ASN1ObjectTrait.class);
     }
 
     /**
@@ -83,31 +66,24 @@ public class TraitDeserializer extends ValueDeserializer<Trait<?, ?>>  {
     }
 
     private static Class<? extends Trait<?, ?>> resolveByAlias(JsonNode traitNode) {
-        Class<? extends Trait<?, ?>> resultByAlias = ASN1ObjectTrait.class;
-        for (String alias : TraitId.getRegisteredAliases()) {
-            if (JsonUtils.has(traitNode, false, alias)) {
-                resultByAlias = TraitId.getTraitClassByAlias(alias);
-                if (resultByAlias != ASN1ObjectTrait.class) {
-                    break;
-                }
-            }
-        }
-        return resultByAlias;
+        return TraitId.getRegisteredAliases().stream()
+                .filter(alias -> JsonUtils.has(traitNode, false, alias))
+                .map(TraitId::getTraitClassByAlias)
+                .filter(clazz -> clazz != ASN1ObjectTrait.class)
+                .findFirst()
+                .orElse(ASN1ObjectTrait.class);
     }
 
     public static final JsonNode checkTraitValueAliases(JsonNode node, String defaultValueKey) {
-        if (node == null || node.isNull()) {
-            return null;
-        }
-
-        for (String alias : TraitId.getRegisteredAliases()) {
-            Optional<JsonNode> hit = JsonUtils.get(node, false, alias);
-            if (hit.isPresent() && !hit.get().isNull()) {
-                return hit.get();
-            }
-        }
-
-        return node.get(defaultValueKey);
+        return Optional.ofNullable(node)
+                .filter(n -> !n.isNull())
+                .flatMap(n -> TraitId.getRegisteredAliases().stream()
+                        .map(alias -> JsonUtils.get(n, false, alias))
+                        .flatMap(Optional::stream)
+                        .filter(hit -> !hit.isNull())
+                        .findFirst()
+                        .or(() -> Optional.ofNullable(n.get(defaultValueKey))))
+                .orElse(null);
     }
 
     public static final JsonNode checkTraitValueAliases(JsonNode node) {

--- a/src/main/java/paccor/json/TraitMapDeserializer.java
+++ b/src/main/java/paccor/json/TraitMapDeserializer.java
@@ -1,11 +1,12 @@
 package paccor.json;
 
-import java.util.ArrayList;
 import java.util.HashSet;
 import java.util.List;
+import java.util.Objects;
 import java.util.Optional;
 import java.util.Set;
 import java.util.stream.Collectors;
+import java.util.stream.StreamSupport;
 import paccor.json.schema.ComponentSchema;
 import org.bouncycastle.asn1.ASN1ObjectIdentifier;
 import paccor.normalization.ComponentIdentifierV2Converter;
@@ -25,25 +26,24 @@ import tools.jackson.databind.node.ObjectNode;
 public class TraitMapDeserializer extends ValueDeserializer<TraitMap> {
     @Override
     public TraitMap deserialize(JsonParser p, DeserializationContext context) throws JacksonException {
-        JsonNode root = context.readTree(p);
-        TraitMap.TraitMapBuilder builder = TraitMap.builder();
-        if (root == null || root.isNull()) {
-            return builder.build();
-        }
-
-        JsonNode traitsNode = root.isObject() ? findTraitsNode(root) : root;
-        JsonNode legacyNode = root.isObject() ? root : null;
-        List<Trait<?, ?>> explicitTraits = collectExplicitTraits(builder, context, traitsNode);
-        if (isLegacyComponentIdentifier(legacyNode)) {
-            mergeLegacyComponentTraits(builder, legacyNode, explicitTraits, context);
-        }
-
-        return builder.build();
+        return Optional.ofNullable(context.readTree(p))
+                .filter(node -> !node.isNull())
+                .map(root -> {
+                    TraitMap.TraitMapBuilder builder = TraitMap.builder();
+                    JsonNode traitsNode = root.isObject() ? findTraitsNode(root) : root;
+                    JsonNode legacyNode = root.isObject() ? root : null;
+                    List<Trait<?, ?>> explicitTraits = collectExplicitTraits(builder, context, traitsNode);
+                    if (isLegacyComponentIdentifier(legacyNode)) {
+                        mergeLegacyComponentTraits(builder, legacyNode, explicitTraits, context);
+                    }
+                    return builder.build();
+                })
+                .orElseGet(() -> TraitMap.builder().build());
     }
 
     private static JsonNode findTraitsNode(JsonNode root) {
         return JsonUtils.get(root, false, "traits")
-                .filter(JsonNode::isArray)
+                .filter(node -> node.isArray() || node.isObject())
                 .orElse(null);
     }
 
@@ -51,18 +51,24 @@ public class TraitMapDeserializer extends ValueDeserializer<TraitMap> {
             TraitMap.TraitMapBuilder builder,
             DeserializationContext context,
             JsonNode traitsNode) {
-        List<Trait<?, ?>> explicitTraits = new ArrayList<>();
-        if (traitsNode == null || !traitsNode.isArray() || traitsNode.isEmpty()) {
-            return explicitTraits;
+        if (traitsNode == null) {
+            return List.of();
         }
-        for (JsonNode traitNode : traitsNode) {
-            Trait<?, ?> trait = readTrait(context, traitNode);
+        if (traitsNode.isArray()) {
+            return StreamSupport.stream(traitsNode.spliterator(), false)
+                    .map(traitNode -> readTrait(context, traitNode))
+                    .filter(Objects::nonNull)
+                    .peek(builder::trait)
+                    .collect(Collectors.toList());
+        }
+        if (traitsNode.isObject()) {
+            Trait<?, ?> trait = readTrait(context, traitsNode);
             if (trait != null) {
-                explicitTraits.add(trait);
                 builder.trait(trait);
+                return List.of(trait);
             }
         }
-        return explicitTraits;
+        return List.of();
     }
 
     private static Trait<?, ?> readTrait(DeserializationContext context, JsonNode traitNode) {
@@ -119,21 +125,13 @@ public class TraitMapDeserializer extends ValueDeserializer<TraitMap> {
             JsonNode legacyNode,
             List<Trait<?, ?>> explicitTraits,
             DeserializationContext context) {
-        try {
-            return ObjectMapperFactory.fromJsonNode(legacyNode, ComponentIdentifierV2.class);
-        } catch (Exception ignored) {
-            // Try patched conversion below.
+        ComponentIdentifierV2 v2 = ObjectMapperFactory.fromJsonNodeSafe(legacyNode, ComponentIdentifierV2.class);
+        if (v2 != null) {
+            return v2;
         }
 
         ObjectNode patched = patchLegacyComponentNode(legacyNode, explicitTraits, context);
-        if (patched == null) {
-            return null;
-        }
-        try {
-            return ObjectMapperFactory.fromJsonNode(patched, ComponentIdentifierV2.class);
-        } catch (Exception ignored) {
-            return null;
-        }
+        return ObjectMapperFactory.fromJsonNodeSafe(patched, ComponentIdentifierV2.class);
     }
 
     private static ObjectNode patchLegacyComponentNode(

--- a/src/main/java/paccor/json/schema/AttributesSchema.java
+++ b/src/main/java/paccor/json/schema/AttributesSchema.java
@@ -9,6 +9,8 @@ public final class AttributesSchema {
     public static final String PLATFORM_CONFIG_URI = "platformConfigUri";
     public static final String PREVIOUS_PLATFORM_CERTIFICATES = "previousPlatformCertificates";
     public static final String CRYPTOGRAPHIC_ANCHORS = "cryptographicAnchors";
+    public static final String PLATFORM_OWNERSHIP = "platformOwnership";
+    public static final String MANUFACTURING_ASSERTIONS = "manufacturingAssertions";
     public static final String TCPA_SPEC_VERSION = "tCPASpecVersion";
     public static final String TPM_MANUFACTURER = "tPMManufacturer";
     public static final String TPM_MODEL = "tPMModel";
@@ -32,6 +34,10 @@ public final class AttributesSchema {
                 "List of previous platform certificates. Accepts explicit trait JSON or FILE-backed certificate entries."),
         CRYPTOGRAPHIC_ANCHORS_FIELD(AttributesSchema.CRYPTOGRAPHIC_ANCHORS,
                 "Cryptographic anchors for the platform. Accepts explicit trait JSON or FILE-backed certificate entries. FILE entries should use CertificateIdentifierTrait categories such as EK, DICE, or SPDM certificate categories."),
+        PLATFORM_OWNERSHIP_FIELD(AttributesSchema.PLATFORM_OWNERSHIP,
+                "This attribute identifies the owner or user of the platform, at the time of issuance of the Platform Certificate or Delta Platform Certificate."),
+        MANUFACTURING_ASSERTIONS_FIELD(AttributesSchema.MANUFACTURING_ASSERTIONS,
+                "This attribute provides a mechanism for platform manufacturers to make platform manufacturer-specific assertions about the manufacturing and supply chain properties of the platform."),
         TCPA_SPEC_VERSION_FIELD(AttributesSchema.TCPA_SPEC_VERSION,
                 "Legacy v1.0 TCPA specification version."),
         TPM_MANUFACTURER_FIELD(AttributesSchema.TPM_MANUFACTURER,

--- a/src/main/java/paccor/model/PlatformCertificateInformationModel.java
+++ b/src/main/java/paccor/model/PlatformCertificateInformationModel.java
@@ -69,6 +69,8 @@ public class PlatformCertificateInformationModel {
     private List<CertificateReference> previousPlatformCertificateObjects;
     private TraitMap cryptographicAnchors;
     private List<CertificateReference> cryptographicAnchorObjects;
+    private TraitMap platformOwnership;
+    private TraitMap manufacturingAssertions;
     private PlatformConfigurationV3 platformConfiguration;
     private TraitMap platformTraits;
     private String platformConfigUri;
@@ -154,6 +156,12 @@ public class PlatformCertificateInformationModel {
             this.cryptographicAnchors = TraitMap.getInstance(attr.cryptographicAnchors());
             this.cryptographicAnchorObjects =
                     ResolvedCertificateReferenceMap.referencesOf(attr.cryptographicAnchors());
+        }
+        if (attr.platformOwnership() != null) {
+            this.platformOwnership = TraitMap.getInstance(attr.platformOwnership());
+        }
+        if (attr.manufacturingAssertions() != null) {
+            this.manufacturingAssertions = TraitMap.getInstance(attr.manufacturingAssertions());
         }
     }
 
@@ -320,6 +328,8 @@ public class PlatformCertificateInformationModel {
         model.setTcgCredentialType(certificate.getTcgCredentialType());
         model.setPreviousPlatformCertificates(certificate.traitMap(TCGObjectIdentifier.tcgAtPreviousPlatformCertificates));
         model.setCryptographicAnchors(certificate.traitMap(TCGObjectIdentifier.tcgAtCryptographicAnchors));
+        model.setPlatformOwnership(certificate.traitMap(TCGObjectIdentifier.tcgAtPlatformOwnership));
+        model.setManufacturingAssertions(certificate.traitMap(TCGObjectIdentifier.tcgAtManufacturingAssertions));
         model.setPlatformConfiguration(certificate.canonicalizedPlatformConfigurationV3());
         model.setPlatformTraits(SubjectAlternativeNameHelper.extractPlatformTraits(
                 certificate.subjectAlternativeNames(),

--- a/src/main/java/paccor/tcg/credential/CommonCriteriaEvaluation.java
+++ b/src/main/java/paccor/tcg/credential/CommonCriteriaEvaluation.java
@@ -119,10 +119,10 @@ public class CommonCriteriaEvaluation extends ASN1Object {
             vec.add(new DERTaggedObject(false, 0, this.evaluationScheme));
         }
         if (this.cCCertificateIssuanceDate != null) {
-            vec.add(new DERTaggedObject(false, 0, this.cCCertificateIssuanceDate));
+            vec.add(new DERTaggedObject(false, 1, this.cCCertificateIssuanceDate));
         }
         if (this.cCCertificateExpiryDate != null) {
-            vec.add(new DERTaggedObject(false, 0, this.cCCertificateExpiryDate));
+            vec.add(new DERTaggedObject(false, 2, this.cCCertificateExpiryDate));
         }
         return new DERSequence(vec);
     }

--- a/src/main/java/paccor/tcg/credential/EntityGeoLocation.java
+++ b/src/main/java/paccor/tcg/credential/EntityGeoLocation.java
@@ -20,6 +20,7 @@ import org.bouncycastle.asn1.ASN1Sequence;
 import org.bouncycastle.asn1.ASN1TaggedObject;
 import org.bouncycastle.asn1.ASN1UTF8String;
 import org.bouncycastle.asn1.DERSequence;
+import org.bouncycastle.asn1.DERTaggedObject;
 
 /**
  * <pre>{@code
@@ -109,19 +110,19 @@ public class EntityGeoLocation extends ASN1Object {
         ASN1EncodableVector vec = new ASN1EncodableVector();
         vec.add(this.countryCode);
         if (this.stateOrProvince != null) {
-            vec.add(this.stateOrProvince);
+            vec.add(new DERTaggedObject(false, 0, stateOrProvince));
         }
         if (this.localityName != null) {
-            vec.add(this.localityName);
+            vec.add(new DERTaggedObject(false, 1, localityName));
         }
         if (this.streetAddress != null) {
-            vec.add(this.streetAddress);
+            vec.add(new DERTaggedObject(false, 2, streetAddress));
         }
         if (this.locationCoords != null) {
-            vec.add(this.locationCoords);
+            vec.add(new DERTaggedObject(false, 3, locationCoords));
         }
         if (this.postalCode != null) {
-            vec.add(this.postalCode);
+            vec.add(new DERTaggedObject(false, 5, postalCode));
         }
         return new DERSequence(vec);
     }

--- a/src/main/java/paccor/tcg/credential/RTMTrait.java
+++ b/src/main/java/paccor/tcg/credential/RTMTrait.java
@@ -65,7 +65,8 @@ public class RTMTrait extends Trait<RTMTypes, RTMTrait> {
         return new RTMTraitBuilderImpl()
                 .traitType(RTMTrait.class)
                 .traitId(TCGObjectIdentifier.tcgTrIdRtm)
-                .traitCategory(TCGObjectIdentifier.tcgTrCatRtm);
+                .traitCategory(TCGObjectIdentifier.tcgTrCatRtm)
+                .traitRegistry(TCGObjectIdentifier.tcgTrRegNone);
     }
 
     /**

--- a/src/main/java/paccor/tcg/credential/TBBSecurityAssertions.java
+++ b/src/main/java/paccor/tcg/credential/TBBSecurityAssertions.java
@@ -3,10 +3,13 @@ package paccor.tcg.credential;
 import com.fasterxml.jackson.annotation.JsonFormat;
 import com.fasterxml.jackson.annotation.JsonClassDescription;
 import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
-import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.annotation.JsonPropertyDescription;
+import java.util.ArrayList;
+import java.util.LinkedHashMap;
 import java.util.List;
+import java.util.Map;
 import java.util.Optional;
+import java.util.Set;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.EqualsAndHashCode;
@@ -20,6 +23,7 @@ import org.bouncycastle.asn1.ASN1EncodableVector;
 import org.bouncycastle.asn1.ASN1IA5String;
 import org.bouncycastle.asn1.ASN1Integer;
 import org.bouncycastle.asn1.ASN1Object;
+import org.bouncycastle.asn1.ASN1ObjectIdentifier;
 import org.bouncycastle.asn1.ASN1Primitive;
 import org.bouncycastle.asn1.ASN1Sequence;
 import org.bouncycastle.asn1.ASN1TaggedObject;
@@ -28,6 +32,9 @@ import org.bouncycastle.asn1.DERTaggedObject;
 
 /**
  * <pre>{@code
+ *
+ * CertSpecVersion V1_0 and V1_1
+ *
  * tBBSecurityAssertions ATTRIBUTE ::= {
  *      WITH SYNTAX TBBSecurityAssertions
  *      ID tcg-at-tbbSecurityAssertions }
@@ -41,6 +48,23 @@ import org.bouncycastle.asn1.DERTaggedObject;
  *      iso9000Uri IA5STRING (SIZE (1..URIMAX) OPTIONAL }
  *
  * Version ::= INTEGER { v1(0) }
+ *
+ * CertSpecVersion V2_0
+ *
+ * tBBSecurityAssertions ATTRIBUTE ::= {
+ *  WITH SYNTAX TBBSecurityAssertions-v3
+ *  ID tcg-at-tbbSecurityAssertions-v3 }
+ *
+ * TBBSecurityAssertions-v3 ::= SEQUENCE (SIZE(1..MAX)) OF Trait
+ *
+ * The tBBSecurityAssertions attribute MAY include:
+ * CommonCriteriaTrait, FIPSLevelTrait, ISO9000Trait,
+ * PlatformFirmwareCapabilitiesTrait, PlatformFirmwareSignatureVerificationTrait,
+ * PlatformFirmwareUpdateComplianceTrait, PlatformHardwareCapabilitiesTrait, RTMTrait,
+ * and URITrait.
+ *
+ * Any other Traits SHALL NOT be included in the tBBSecurityAssertions attribute.
+ *
  * }</pre>
  */
 @AllArgsConstructor
@@ -55,27 +79,26 @@ import org.bouncycastle.asn1.DERTaggedObject;
 @ToString
 public class TBBSecurityAssertions extends ASN1Object {
 	private static final int MIN_SEQUENCE_SIZE = 0;
-	private static final int MAX_SEQUENCE_SIZE = 6;
-	private static final int ASN1BOOLEAN_MAX_POSITION_IN_SEQUENCE = 4;
-	private static final int ASN1STRING_MAX_POSITION_IN_SEQUENCE = 5;
 
 	@Builder.Default
-	@JsonPropertyDescription("Assertion version. Defaults to v1.")
+	@JsonPropertyDescription("Assertion version. Optional, omitted in V2.0.")
+	private final ASN1Integer version = new ASN1Integer(0);
+
+	@JsonPropertyDescription("Collection of traits for assertions.")
 	@NonNull
-	private final ASN1Integer version = new ASN1Integer(0); // default = 0
-	@JsonPropertyDescription("Optional Common Criteria assertions.")
-	private final CommonCriteriaMeasures ccInfo; // optional, tagged 0
-	@JsonPropertyDescription("Optional FIPS level statement.")
-	private final FIPSLevel fipsLevel; // optional, tagged 1
-	@JsonPropertyDescription("Optional measurement root type.")
-	private final MeasurementRootType rtmType; // optional, tagged 2
-	@Builder.Default
-	@JsonProperty(defaultValue = "false")
-	@JsonPropertyDescription("Whether ISO 9000 certification is asserted. Defaults to false.")
-	@NonNull
-	private final ASN1Boolean iso9000Certified = ASN1Boolean.FALSE; // default = false
-	@JsonPropertyDescription("Optional URI providing ISO 9000 certification details.")
-	private final ASN1IA5String iso9000Uri; // optional
+	private final TraitMap traits;
+
+	public static final Set<Class<? extends Trait<?, ?>>> ALLOWED_TRAIT_TYPES = Set.of(
+			CommonCriteriaTrait.class,
+			FIPSLevelTrait.class,
+			ISO9000Trait.class,
+			PlatformFirmwareCapabilitiesTrait.class,
+			PlatformFirmwareSignatureVerificationTrait.class,
+			PlatformFirmwareUpdateComplianceTrait.class,
+			PlatformHardwareCapabilitiesTrait.class,
+			RTMTrait.class,
+			URITrait.class
+	);
 
 	/**
 	 * Attempts to cast the provided object.
@@ -87,8 +110,8 @@ public class TBBSecurityAssertions extends ASN1Object {
 		if (obj == null || obj instanceof TBBSecurityAssertions) {
 			return (TBBSecurityAssertions) obj;
 		}
-        if (obj instanceof ASN1Sequence || obj instanceof ASN1TaggedObject) {
-            return fromASN1Sequence(ASN1Utils.getSequence(obj));
+		if (obj instanceof ASN1Sequence || obj instanceof ASN1TaggedObject) {
+			return fromASN1Sequence(ASN1Utils.getSequence(obj));
 		}
 		throw new IllegalArgumentException("Illegal argument in getInstance: " + obj.getClass().getName());
 	}
@@ -103,13 +126,22 @@ public class TBBSecurityAssertions extends ASN1Object {
 			throw new IllegalArgumentException("Bad sequence size: " + seq.size());
 		}
 
+		// Heuristic to check if it's a TraitMap (V3) or legacy.
+		// TraitMap is SEQUENCE OF Trait. Trait is SEQUENCE { traitId OID, ... }
+		if (seq.size() > 0 && seq.getObjectAt(0) instanceof ASN1Sequence subSeq) {
+			if (subSeq.size() > 0 && subSeq.getObjectAt(0) instanceof ASN1ObjectIdentifier) {
+				return new TBBSecurityAssertions(null, TraitMap.fromASN1Sequence(seq));
+			}
+		}
+
 		TBBSecurityAssertions.TBBSecurityAssertionsBuilder builder = TBBSecurityAssertions.builder();
 
 		List<ASN1Object> untaggedElements = ASN1Utils.listUntaggedElements(seq);
 		ASN1Sequence untaggedSequence = new DERSequence(ASN1Utils.toASN1EncodableVector(untaggedElements));
 
-		// version can only be in the first position
+		// version can only be in the first position. We don't store it but we parse it to consume it.
 		builder.version(ASN1Utils.safeGetDefaultElementFromSequence(untaggedSequence, 0, new ASN1Integer(0), ASN1Utils::getInteger));
+
 		// iso9000Certified could be in any position 0 through 4, 0 to 1 in the untaggedSequence
 		builder.iso9000Certified(ASN1Utils.safeGetFirstInstanceFromSequenceGivenRange(untaggedSequence, 0, 4, ASN1Boolean.FALSE, ASN1Utils::getBoolean));
 		// iso9000Uri could be in any position 0 through 5, 0 to 2 in the untaggedSequence. If not present, don't give anything to the builder
@@ -129,28 +161,142 @@ public class TBBSecurityAssertions extends ASN1Object {
 	}
 
 	/**
-	 * @return This object as an ASN1Sequence
+	 * @return This object as an ASN1Sequence in legacy format (V1.x)
 	 */
 	public ASN1Primitive toASN1Primitive() {
 		ASN1EncodableVector vec = new ASN1EncodableVector();
-		if (version.getValue().longValue() != 0) {
+		if (version != null && version.getValue().longValue() != 0) {
 			vec.add(version);
 		}
-		if (ccInfo != null) {
-			vec.add(new DERTaggedObject(false, 0, ccInfo));
-		}
-		if (fipsLevel != null) {
-			vec.add(new DERTaggedObject(false, 1, fipsLevel));
-		}
-		if (rtmType != null) {
-			vec.add(new DERTaggedObject(false, 2, rtmType));
-		}
-		if (iso9000Certified.isTrue()) {
-			vec.add(iso9000Certified);
-		}
-		if (iso9000Uri != null) {
-			vec.add(iso9000Uri);
+
+		getCcInfo().ifPresent(ccInfo -> vec.add(new DERTaggedObject(false, 0, ccInfo)));
+		getFipsLevel().ifPresent(fipsLevel -> vec.add(new DERTaggedObject(false, 1, fipsLevel)));
+		getRtmType().ifPresent(rtmType -> vec.add(new DERTaggedObject(false, 2, rtmType)));
+
+		ISO9000Certification iso = traits.firstTraitValue(ISO9000Trait.class).orElse(null);
+		if (iso != null) {
+			if (iso.getIso9000Certified().isTrue()) {
+				vec.add(iso.getIso9000Certified());
+			}
+			if (iso.getIso9000Uri() != null) {
+				vec.add(iso.getIso9000Uri());
+			}
 		}
 		return new DERSequence(vec);
+	}
+
+	/**
+	 * Convert to a TraitMap representation, filtering for only allowed traits.
+	 * @return {@link TraitMap}
+	 */
+	public TraitMap toTraitMap() {
+		return traits.filter(ALLOWED_TRAIT_TYPES);
+	}
+
+	@JsonPropertyDescription("Optional Common Criteria assertions.")
+	public Optional<CommonCriteriaMeasures> getCcInfo() {
+		return traits.firstTraitValue(CommonCriteriaTrait.class)
+				.map(CommonCriteriaEvaluation::getCCMeasures);
+	}
+
+	@JsonPropertyDescription("Optional FIPS level statement.")
+	public Optional<FIPSLevel> getFipsLevel() {
+		return traits.firstTraitValue(FIPSLevelTrait.class);
+	}
+
+	@JsonPropertyDescription("Optional measurement root type.")
+	public Optional<MeasurementRootType> getRtmType() {
+		return traits.firstTraitValue(RTMTrait.class)
+				.map(types -> new MeasurementRootType(types.getValue()));
+	}
+
+	@JsonPropertyDescription("Whether ISO 9000 certification is asserted. Defaults to false.")
+	public ASN1Boolean getIso9000Certified() {
+		return traits.firstTraitValue(ISO9000Trait.class)
+				.map(ISO9000Certification::getIso9000Certified)
+				.orElse(ASN1Boolean.FALSE);
+	}
+
+	@JsonPropertyDescription("Optional URI providing ISO 9000 certification details.")
+	public Optional<ASN1IA5String> getIso9000Uri() {
+		return traits.firstTraitValue(ISO9000Trait.class)
+				.map(ISO9000Certification::getIso9000Uri);
+	}
+
+	public Optional<ASN1Integer> getVersion() {
+		return Optional.ofNullable(version);
+	}
+
+	public static class TBBSecurityAssertionsBuilder {
+		private ASN1Integer version = new ASN1Integer(0);
+		private final TraitMap traits = new TraitMap(new LinkedHashMap<>());
+
+		public TBBSecurityAssertionsBuilder version(ASN1Integer version) {
+			if (version != null) {
+				this.version = version;
+			}
+			return this;
+		}
+
+		public TBBSecurityAssertionsBuilder traits(TraitMap traits) {
+			if (traits != null) {
+				this.traits.putAll(traits);
+			}
+			return this;
+		}
+
+		public TBBSecurityAssertionsBuilder ccInfo(CommonCriteriaMeasures ccInfo) {
+			Optional.ofNullable(ccInfo).ifPresent(info ->
+					traits.setSingleTrait(CommonCriteriaTrait.builder()
+							.traitValue(CommonCriteriaEvaluation.builder()
+									.cCMeasures(info)
+									.cCCertificateNumber(ASN1Utils.getUTF8String(""))
+									.cCCertificateAuthority(ASN1Utils.getUTF8String(""))
+									.build())
+							.build())
+			);
+			return this;
+		}
+
+		public TBBSecurityAssertionsBuilder fipsLevel(FIPSLevel fipsLevel) {
+			Optional.ofNullable(fipsLevel).ifPresent(level ->
+					traits.setSingleTrait(FIPSLevelTrait.builder().traitValue(level).build())
+			);
+			return this;
+		}
+
+		public TBBSecurityAssertionsBuilder rtmType(MeasurementRootType rtmType) {
+			Optional.ofNullable(rtmType).ifPresent(rtm ->
+					traits.setSingleTrait(RTMTrait.builder().traitValue(new RTMTypes(rtm.getValue())).build())
+			);
+			return this;
+		}
+
+		public TBBSecurityAssertionsBuilder iso9000Certified(ASN1Boolean certified) {
+			ISO9000Certification updated = getIso9000Certification()
+					.map(current -> current.toBuilder().iso9000Certified(certified).build())
+					.orElseGet(() -> ISO9000Certification.builder().iso9000Certified(certified).build());
+			return iso9000Certification(updated);
+		}
+
+		public TBBSecurityAssertionsBuilder iso9000Uri(ASN1IA5String uri) {
+			ISO9000Certification updated = getIso9000Certification()
+					.map(current -> current.toBuilder().iso9000Uri(uri).build())
+					.orElseGet(() -> ISO9000Certification.builder().iso9000Uri(uri).build());
+			return iso9000Certification(updated);
+		}
+
+		private TBBSecurityAssertionsBuilder iso9000Certification(ISO9000Certification certification) {
+			traits.setSingleTrait(ISO9000Trait.builder().traitValue(certification).build());
+			return this;
+		}
+
+		private Optional<ISO9000Certification> getIso9000Certification() {
+			return traits.firstTrait(ISO9000Trait.class).map(Trait::getTraitValue);
+		}
+
+		public TBBSecurityAssertions build() {
+			return new TBBSecurityAssertions(version, traits);
+		}
 	}
 }

--- a/src/main/java/paccor/tcg/credential/TraitCollection.java
+++ b/src/main/java/paccor/tcg/credential/TraitCollection.java
@@ -5,12 +5,18 @@ import java.util.ArrayList;
 import java.util.Iterator;
 import java.util.List;
 import java.util.Optional;
+import java.util.Set;
 import java.util.stream.Stream;
 import lombok.NonNull;
+import org.bouncycastle.asn1.ASN1EncodableVector;
+import org.bouncycastle.asn1.ASN1Object;
 import org.bouncycastle.asn1.ASN1ObjectIdentifier;
+import org.bouncycastle.asn1.ASN1Primitive;
+import org.bouncycastle.asn1.ASN1Sequence;
+import org.bouncycastle.asn1.DERSequence;
 
 @JsonClassDescription("Ordered flat collection of Trait entries.")
-public final class TraitCollection implements Iterable<Trait<?, ?>> {
+public final class TraitCollection extends ASN1Object implements Iterable<Trait<?, ?>> {
     private final List<Trait<?, ?>> traits;
 
     public TraitCollection(List<? extends Trait<?, ?>> traits) {
@@ -47,6 +53,18 @@ public final class TraitCollection implements Iterable<Trait<?, ?>> {
 
     public Stream<Trait<?, ?>> stream() {
         return traits.stream();
+    }
+
+    public <T extends Trait<?, ?>> Optional<T> firstTrait(Class<T> traitType) {
+        return traits.stream()
+                .filter(traitType::isInstance)
+                .map(traitType::cast)
+                .findFirst();
+    }
+
+    public <TraitValueType extends ASN1Object, TraitType extends Trait<TraitValueType, TraitType>> Optional<TraitValueType> firstTraitValue(Class<TraitType> traitType) {
+        return firstTrait(traitType)
+                .map(TraitType::getTraitValue);
     }
 
     public <T extends Trait<?, ?>> List<T> traits(Class<T> traitType) {
@@ -95,8 +113,44 @@ public final class TraitCollection implements Iterable<Trait<?, ?>> {
         });
     }
 
+    public TraitCollection filter(Set<Class<? extends Trait<?, ?>>> allowedTypes) {
+        return new TraitCollection(traits.stream()
+                .filter(t -> allowedTypes.contains(t.getClass()))
+                .toList());
+    }
+
     public TraitMap toTraitMap() {
         return TraitMap.fromTraits(traits);
+    }
+
+    @Override
+    public ASN1Primitive toASN1Primitive() {
+        return new DERSequence(ASN1Utils.toASN1EncodableVector(traits));
+    }
+
+    public static TraitCollection fromASN1Sequence(ASN1Sequence seq) {
+        if (seq == null) return empty();
+        List<Trait<?, ?>> list = new ArrayList<>();
+        for (int i = 0; i < seq.size(); i++) {
+            ASN1Sequence traitSeq = ASN1Utils.getSequence(seq.getObjectAt(i));
+            ASN1ObjectIdentifier traitId = ASN1Utils.getOID(traitSeq.getObjectAt(0));
+            Class<? extends Trait<?, ?>> traitClass = TraitId.getTraitClassForId(traitId);
+            list.add(Trait.getInstance(traitSeq, (Class) traitClass));
+        }
+        return new TraitCollection(list);
+    }
+
+    public static TraitCollection getInstance(Object obj) {
+        if (obj == null || obj instanceof TraitCollection) {
+            return (TraitCollection) obj;
+        }
+        if (obj instanceof ASN1Sequence) {
+            return fromASN1Sequence((ASN1Sequence) obj);
+        }
+        if (obj instanceof TraitMap map) {
+            return from(map);
+        }
+        throw new IllegalArgumentException("Unknown object type: " + obj.getClass().getName());
     }
 
     @NonNull

--- a/src/main/java/paccor/tcg/credential/TraitMap.java
+++ b/src/main/java/paccor/tcg/credential/TraitMap.java
@@ -9,7 +9,7 @@ import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collection;
 import java.util.Collections;
-import java.util.HashMap;
+import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Objects;
@@ -24,7 +24,6 @@ import lombok.Getter;
 import lombok.NoArgsConstructor;
 import lombok.NonNull;
 import lombok.ToString;
-import org.bouncycastle.asn1.ASN1EncodableVector;
 import org.bouncycastle.asn1.ASN1Object;
 import org.bouncycastle.asn1.ASN1Primitive;
 import org.bouncycastle.asn1.ASN1Sequence;
@@ -35,7 +34,7 @@ import tools.jackson.databind.annotation.JsonDeserialize;
 
 /**
  * <pre>{@code
- * &lt;?&gt; ::= SEQUENCE(SIZE(1..MAX)) OF Trait
+ * <?> ::= SEQUENCE(SIZE(1..MAX)) OF Trait
  * }</pre>
  */
 @AllArgsConstructor
@@ -55,12 +54,6 @@ public class TraitMap extends ASN1Object implements Map<Class<? extends Trait<?,
     @Size(min = 1)
     private final Map<Class<? extends Trait<?, ?>>, List<Trait<?, ?>>> traits;
 
-    /**
-     * Attempts to cast the provided object to TraitMap.
-     * If the object is an ASN1Sequence, the object is parsed by fromASN1Sequence.
-     * @param obj the object to parse
-     * @return TraitMap
-     */
     public static TraitMap getInstance(Object obj) {
         if (obj == null || obj instanceof TraitMap) {
             return (TraitMap) obj;
@@ -71,11 +64,6 @@ public class TraitMap extends ASN1Object implements Map<Class<? extends Trait<?,
         throw new IllegalArgumentException("Illegal argument in getInstance: " + obj.getClass().getName());
     }
 
-    /**
-     * Attempts to parse the given ASN1Sequence.
-     * @param seq An ASN1Sequence
-     * @return TraitMap
-     */
     public static final TraitMap fromASN1Sequence(@NonNull ASN1Sequence seq) {
         if (seq.size() < TraitMap.MIN_SEQUENCE_SIZE) {
             throw new IllegalArgumentException("Bad sequence size: " + seq.size());
@@ -94,35 +82,43 @@ public class TraitMap extends ASN1Object implements Map<Class<? extends Trait<?,
         return builder.build();
     }
 
-    /**
-     * Flatten the trait map into a single list.
-     * @return List of Traits
-     */
     public final List<Trait<?, ?>> flattenTraits() {
-        if (getTraits() == null) return List.of();
-        return getTraits().values().stream().filter(Objects::nonNull).flatMap(Collection::stream).toList();
+        if (traits == null) return List.of();
+        return traits.values().stream().filter(Objects::nonNull).flatMap(Collection::stream).toList();
+    }
+
+    public final <TraitValueType extends ASN1Object, TraitType extends Trait<TraitValueType, TraitType>> Optional<TraitValueType> firstTraitValue(Class<TraitType> traitType) {
+        return Optional.ofNullable(traits)
+                .map(m -> m.get(traitType))
+                .flatMap(list -> list.stream().findFirst())
+                .map(traitType::cast)
+                .map(TraitType::getTraitValue);
+    }
+
+    public final <T extends Trait<?, ?>> Optional<T> firstTrait(Class<T> traitType) {
+        return Optional.ofNullable(traits)
+                .map(m -> m.get(traitType))
+                .flatMap(list -> list.stream().findFirst())
+                .map(traitType::cast);
     }
 
     public final <TraitValueType extends ASN1Object, TraitType extends Trait<TraitValueType, TraitType>> TraitValueType firstValueOfType(Class<TraitType> traitType) {
-        return Optional.ofNullable(traits)
-                .map(list -> traits.get(traitType))
-                .flatMap(list -> list.stream().findFirst())
-                .map(traitType::cast)
-                .map(TraitType::getTraitValue)
-                .orElse(null);
+        return firstTraitValue(traitType).orElse(null);
     }
 
-    /**
-     * Flatten the trait map into a single list of the specified type.
-     * @param traitType The type of Trait to focus on
-     * @return List of Traits of the specified type
-     * @param <TraitType> The type of Trait to focus on
-     */
     public final <TraitValueType extends ASN1Object, TraitType extends Trait<TraitValueType, TraitType>> List<TraitType> get(Class<TraitType> traitType) {
-        return flattenTraits().stream()
-                .filter(traitType::isInstance)
-                .map(traitType::cast)
-                .toList();
+        return Optional.ofNullable(traits)
+                .map(m -> m.get(traitType))
+                .map(list -> list.stream().map(traitType::cast).toList())
+                .orElseGet(List::of);
+    }
+
+    public final TraitMap filter(Set<Class<? extends Trait<?, ?>>> allowedTypes) {
+        TraitMapBuilder builder = TraitMap.builder();
+        flattenTraits().stream()
+                .filter(t -> allowedTypes.contains(t.getClass()))
+                .forEach(builder::trait);
+        return builder.build();
     }
 
     @Override
@@ -185,16 +181,19 @@ public class TraitMap extends ASN1Object implements Map<Class<? extends Trait<?,
         if (traits == null) {
             throw new UnsupportedOperationException("Internal traits map is immutable");
         }
-        for (Entry<? extends Class<? extends Trait<?, ?>>, ? extends List<Trait<?, ?>>> entry : map.entrySet()) {
-            put(entry.getKey(), entry.getValue());
+        map.forEach(this::put);
+    }
+
+    public void setSingleTrait(@NonNull Trait<?, ?> trait) {
+        if (traits == null) {
+            throw new UnsupportedOperationException("Internal traits map is immutable");
         }
+        traits.put(trait.getTraitType(), new ArrayList<>(List.of(trait)));
     }
 
     @Override
     public void clear() {
-        if (traits != null) {
-            traits.clear();
-        }
+        Optional.ofNullable(traits).ifPresent(Map::clear);
     }
 
     @NonNull
@@ -215,42 +214,23 @@ public class TraitMap extends ASN1Object implements Map<Class<? extends Trait<?,
         return traits != null ? traits.entrySet() : Collections.emptySet();
     }
 
-    /**
-     * @return This object as an ASN1Sequence
-     */
     public ASN1Primitive toASN1Primitive() {
-        ASN1EncodableVector vec = new ASN1EncodableVector();
-        if (traits != null) {
-            vec = ASN1Utils.toASN1EncodableVector(
-                    traits.values().stream()
-                            .filter(Objects::nonNull)
-                            .flatMap(Collection::stream)
-                            .toList());
-        }
-        return new DERSequence(vec);
+        return new DERSequence(ASN1Utils.toASN1EncodableVector(flattenTraits()));
     }
 
-    /**
-     * The rest of this builder is generated by lombok Builder annotation
-     */
     public static class TraitMapBuilder {
-        public TraitMapBuilder trait(Trait<?, ?> traitObj) {
-            if (traits == null) {
-                traits = new HashMap<>();
-            }
-            if (!traits.containsKey(traitObj.getTraitType())) {
-                traits.put(traitObj.getTraitType(), new ArrayList<>());
-            }
-            List<Trait<?, ?>> list = traits.get(traitObj.getTraitType());
-            list.add(traitObj);
-            traits.put(traitObj.getTraitType(), list);
+        private Map<Class<? extends Trait<?, ?>>, List<Trait<?, ?>>> traits = new LinkedHashMap<>();
+
+        public TraitMapBuilder setSingleTrait(Trait<?, ?> traitObj) {
+            traits.put(traitObj.getTraitType(), new ArrayList<>(List.of(traitObj)));
             return this;
         }
 
-        /**
-         * Attempts to recover Traits from the ASN1Sequence and then read their TraitID and process them into appropriate types.
-         * @param seq ASN1Sequence
-         */
+        public TraitMapBuilder trait(Trait<?, ?> traitObj) {
+            traits.computeIfAbsent(traitObj.getTraitType(), _ -> new ArrayList<>()).add(traitObj);
+            return this;
+        }
+
         public final void traitsFromSequence(@NonNull ASN1Sequence seq) {
             Arrays.stream(seq.toArray())
                     .map(obj -> (ASN1Object)obj)
@@ -266,10 +246,6 @@ public class TraitMap extends ASN1Object implements Map<Class<? extends Trait<?,
                     });
         }
 
-        /**
-         * Read traits from the JsonNode into the TraitMap.
-         * @param refNode JsonNode
-         */
         public final void traitsFromJson(@NonNull JsonNode refNode) {
             ObjectMapperFactory.fromJsonNode(refNode, TraitMap.class).flattenTraits()
                     .forEach(this::trait);

--- a/src/main/java/paccor/tcg/credential/TraitMap.java
+++ b/src/main/java/paccor/tcg/credential/TraitMap.java
@@ -15,6 +15,8 @@ import java.util.Map;
 import java.util.Objects;
 import java.util.Optional;
 import java.util.Set;
+import java.util.stream.Collectors;
+import org.bouncycastle.asn1.ASN1ObjectIdentifier;
 import paccor.json.ObjectMapperFactory;
 import paccor.json.TraitMapDeserializer;
 import lombok.AllArgsConstructor;
@@ -74,12 +76,36 @@ public class TraitMap extends ASN1Object implements Map<Class<? extends Trait<?,
         return builder.build();
     }
 
-    public static TraitMap fromTraits(List<? extends Trait<?, ?>> traits) {
+    public static final TraitMap fromTraits(List<? extends Trait<?, ?>> traits) {
         TraitMapBuilder builder = TraitMap.builder();
         if (traits != null) {
             traits.forEach(builder::trait);
         }
         return builder.build();
+    }
+
+    public static final void validateTraitMap(
+            TraitMap traits,
+            String context,
+            Set<Class<? extends Trait<?, ?>>> allowedTypes,
+            Set<ASN1ObjectIdentifier> requiredCategories,
+            List<String> issues) {
+        if (traits == null || traits.isEmpty()) return;
+
+        Optional.ofNullable(allowedTypes).ifPresent(allowed ->
+                traits.keySet().stream()
+                        .filter(type -> !allowed.contains(type))
+                        .forEach(type -> issues.add(context + " contains unsupported trait type: " + type.getSimpleName()))
+        );
+
+        Optional.ofNullable(requiredCategories).ifPresent(required -> {
+            Set<ASN1ObjectIdentifier> presentCategories = traits.flattenTraits().stream()
+                    .map(Trait::getTraitCategory)
+                    .collect(Collectors.toSet());
+            required.stream()
+                    .filter(req -> !presentCategories.contains(req))
+                    .forEach(req -> issues.add(context + " is missing required trait category: " + req.getId()));
+        });
     }
 
     public final List<Trait<?, ?>> flattenTraits() {
@@ -220,11 +246,6 @@ public class TraitMap extends ASN1Object implements Map<Class<? extends Trait<?,
 
     public static class TraitMapBuilder {
         private Map<Class<? extends Trait<?, ?>>, List<Trait<?, ?>>> traits = new LinkedHashMap<>();
-
-        public TraitMapBuilder setSingleTrait(Trait<?, ?> traitObj) {
-            traits.put(traitObj.getTraitType(), new ArrayList<>(List.of(traitObj)));
-            return this;
-        }
 
         public TraitMapBuilder trait(Trait<?, ?> traitObj) {
             traits.computeIfAbsent(traitObj.getTraitType(), _ -> new ArrayList<>()).add(traitObj);

--- a/src/test/java/paccor/cert/TbbSecurityAssertionsValidationTest.java
+++ b/src/test/java/paccor/cert/TbbSecurityAssertionsValidationTest.java
@@ -1,0 +1,91 @@
+package paccor.cert;
+
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+import paccor.model.PlatformCertificateInformationModel;
+import paccor.tcg.credential.*;
+import java.util.List;
+import org.bouncycastle.asn1.ASN1Boolean;
+
+public class TbbSecurityAssertionsValidationTest {
+
+    @Test
+    void validateTbbSecurityAssertions_v20_flagsUnsupportedTraits() {
+        PlatformCertificateInformationModel pi = new PlatformCertificateInformationModel();
+        
+        // Add an unsupported trait to TBB Security Assertions (BooleanTrait is not allowed)
+        TraitMap traits = TraitMap.builder()
+                .trait(FIPSLevelTrait.builder()
+                        .traitValue(FIPSLevel.builder()
+                                .version(new org.bouncycastle.asn1.DERIA5String("140-2"))
+                                .level(new SecurityLevel(1))
+                                .build())
+                        .build())
+                .trait(BooleanTrait.builder()
+                        .traitId(TCGObjectIdentifier.tcgTrIdIso9000Level) // reusing an OID for simplicity
+                        .traitValue(ASN1Boolean.TRUE)
+                        .build())
+                .build();
+        
+        pi.setTbbSecurityAssertions(TBBSecurityAssertions.builder().traits(traits).build());
+
+        List<String> issues = TbsFinalizer.validateAc(CertificateProfile.platformV2_0Ac(), pi);
+        
+        Assertions.assertTrue(issues.stream().anyMatch(s -> s.contains("TBBSecurityAssertions contains unsupported trait type: BooleanTrait")),
+                "Should have flagged unsupported trait type, but got: " + issues);
+    }
+
+    @Test
+    void validateTbbSecurityAssertions_v20_acceptsAllowedTraits() {
+        PlatformCertificateInformationModel pi = new PlatformCertificateInformationModel();
+        
+        TraitMap traits = TraitMap.builder()
+                .trait(FIPSLevelTrait.builder()
+                        .traitValue(FIPSLevel.builder()
+                                .version(new org.bouncycastle.asn1.DERIA5String("140-2"))
+                                .level(new SecurityLevel(1))
+                                .build())
+                        .build())
+                .trait(RTMTrait.builder().traitValue(new RTMTypes(1)).build())
+                .build();
+        
+        pi.setTbbSecurityAssertions(TBBSecurityAssertions.builder().traits(traits).build());
+
+        List<String> issues = TbsFinalizer.validateAc(CertificateProfile.platformV2_0Ac(), pi);
+        
+        Assertions.assertFalse(issues.stream().anyMatch(s -> s.contains("TBBSecurityAssertions contains unsupported trait type")),
+                "Should have accepted allowed trait types, but got: " + issues);
+    }
+    
+    @Test
+    void validateTbbSecurityAssertions_v10_doesNotFlagTraits() {
+        PlatformCertificateInformationModel pi = new PlatformCertificateInformationModel();
+        
+        // V1.0 doesn't use TraitMap for TBBSecurityAssertions in our validation logic (it uses the legacy structure)
+        // Even if we provide traits, the current validation for V1.0 doesn't check them as a TraitMap.
+        TraitMap traits = TraitMap.builder()
+                .trait(BooleanTrait.builder().traitValue(ASN1Boolean.TRUE).build())
+                .build();
+        
+        pi.setTbbSecurityAssertions(TBBSecurityAssertions.builder().traits(traits).build());
+
+        List<String> issues = TbsFinalizer.validateAc(CertificateProfile.platformV1_0Ac(), pi);
+        
+        Assertions.assertFalse(issues.stream().anyMatch(s -> s.contains("TBBSecurityAssertions contains unsupported trait type")),
+                "Should not have flagged traits for V1.0, but got: " + issues);
+    }
+
+    @Test
+    void testToTraitMapConversion() {
+        TBBSecurityAssertions v1 = TBBSecurityAssertions.builder()
+                .fipsLevel(FIPSLevel.builder()
+                        .version(new org.bouncycastle.asn1.DERIA5String("140-2"))
+                        .level(new SecurityLevel(1))
+                        .build())
+                .build();
+
+        TraitMap traits = v1.toTraitMap();
+        Assertions.assertTrue(traits.containsKey(FIPSLevelTrait.class));
+        Assertions.assertEquals(1, traits.get(FIPSLevelTrait.class).size());
+    }
+}

--- a/src/test/java/paccor/cert/TbsFinalizerTest.java
+++ b/src/test/java/paccor/cert/TbsFinalizerTest.java
@@ -17,9 +17,19 @@ import org.bouncycastle.asn1.x509.KeyPurposeId;
 import org.bouncycastle.util.encoders.Base64;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
+import paccor.tcg.credential.ComponentIdentifierV11Trait;
+import paccor.tcg.credential.ComponentIdentifierV2;
+import paccor.tcg.credential.ComponentClass;
+import paccor.tcg.credential.UTF8StringTrait;
+import paccor.tcg.credential.TraitMap;
+import paccor.tcg.credential.TCGObjectIdentifier;
+import paccor.tcg.credential.PlatformConfigurationV3;
+import paccor.tcg.credential.PlatformPropertiesV2;
+import org.bouncycastle.asn1.DEROctetString;
+import org.bouncycastle.asn1.DERUTF8String;
 import paccor.tcg.credential.TCGSpecificationVersion;
 
-public class FinalizeHelperTest {
+public class TbsFinalizerTest {
     private static final AlgorithmIdentifier SIG_ALG =
             new AlgorithmIdentifier(PKCSObjectIdentifiers.sha256WithRSAEncryption);
 
@@ -99,6 +109,7 @@ public class FinalizeHelperTest {
         pi.setNotBefore(new Date(System.currentTimeMillis()));
         pi.setNotAfter(new Date(System.currentTimeMillis() + 3600000));
         pi.setHolder(new HolderInfo(null, null));
+        pi.setPlatformTraits(TbsEncoderDerivedExtensionsTest.samplePlatformTraits());
 
         pi.putExtension(TbsEncoderDerivedExtensionsTest.dummyExtension(
                 Extension.authorityKeyIdentifier, "Authority Key Identifier"));
@@ -172,6 +183,146 @@ public class FinalizeHelperTest {
         Assertions.assertTrue(issues.contains("Basic Constraints CA flag must be FALSE for PKC."));
         Assertions.assertTrue(issues.contains("Extended Key Usage must include " + KeyPurposeId.getInstance(
                 CertTypeResolver.toOid(CertKind.PKC, CertType.BASE)).getId() + "."));
+    }
+
+    @Test
+    void validateAc_v20_requiresPlatformTraits() {
+        PlatformCertificateInformationModel pi = sampleV20Model();
+        pi.setPlatformTraits(null); // Missing required traits
+
+        List<String> issues = TbsFinalizer.validateAc(CertificateProfile.platformV2_0Ac(), pi);
+        Assertions.assertTrue(issues.contains("Subject Alternative Name must contain a PlatformIdentifier sequence with traits."));
+    }
+
+    @Test
+    void validateAc_v20_checksRequiredPlatformTraits() {
+        PlatformCertificateInformationModel pi = sampleV20Model();
+        TraitMap traits = TraitMap.builder()
+                .trait(UTF8StringTrait.builder()
+                        .traitCategory(TCGObjectIdentifier.tcgTrCatPlatformManufacturer)
+                        .traitValue(new DERUTF8String("Manufacturer"))
+                        .build())
+                .build();
+        pi.setPlatformTraits(traits); // Missing Model and Version
+
+        List<String> issues = TbsFinalizer.validateAc(CertificateProfile.platformV2_0Ac(), pi);
+        Assertions.assertTrue(issues.contains("PlatformIdentifier is missing required trait category: " + TCGObjectIdentifier.tcgTrCatPlatformModel.getId()));
+        Assertions.assertTrue(issues.contains("PlatformIdentifier is missing required trait category: " + TCGObjectIdentifier.tcgTrCatPlatformVersion.getId()));
+    }
+
+    @Test
+    void validateAc_v20_checksComponentV11Exclusivity() {
+        PlatformCertificateInformationModel pi = sampleV20Model();
+        pi.setPlatformTraits(samplePlatformTraits());
+
+        ComponentIdentifierV11Trait v11 = ComponentIdentifierV11Trait.builder()
+                .traitValue(ComponentIdentifierV2.builder()
+                        .componentClass(new ComponentClass(TCGObjectIdentifier.tcgRegistryComponentClassTcg, new DEROctetString(new byte[] {0, 0, 0, 1})))
+                        .componentManufacturer(new DERUTF8String("man"))
+                        .componentModel(new DERUTF8String("mod"))
+                        .build())
+                .build();
+
+        TraitMap component = TraitMap.builder()
+                .trait(v11)
+                .trait(UTF8StringTrait.builder()
+                        .traitCategory(TCGObjectIdentifier.tcgTrCatComponentClass)
+                        .traitValue(new DERUTF8String("another"))
+                        .build())
+                .build();
+
+        pi.setPlatformConfiguration(PlatformConfigurationV3.builder()
+                .platformComponent(component)
+                .build());
+
+        List<String> issues = TbsFinalizer.validateAc(CertificateProfile.platformV2_0Ac(), pi);
+        Assertions.assertTrue(issues.contains("Component[0] containing ComponentIdentifierV11Trait SHALL NOT contain any other trait."));
+    }
+
+    @Test
+    void validateAc_v20_checksRequiredComponentTraits() {
+        PlatformCertificateInformationModel pi = sampleV20Model();
+        pi.setPlatformTraits(samplePlatformTraits());
+
+        TraitMap component = TraitMap.builder()
+                .trait(UTF8StringTrait.builder()
+                        .traitCategory(TCGObjectIdentifier.tcgTrCatComponentManufacturer)
+                        .traitValue(new DERUTF8String("man"))
+                        .build())
+                .build();
+
+        pi.setPlatformConfiguration(PlatformConfigurationV3.builder()
+                .platformComponent(component)
+                .build());
+
+        List<String> issues = TbsFinalizer.validateAc(CertificateProfile.platformV2_0Ac(), pi);
+        Assertions.assertTrue(issues.contains("Component[0] is missing required trait category: " + TCGObjectIdentifier.tcgTrCatComponentClass.getId()));
+        Assertions.assertTrue(issues.contains("Component[0] is missing required trait category: " + TCGObjectIdentifier.tcgTrCatComponentModel.getId()));
+    }
+
+    @Test
+    void validateAc_v20_deltaRequiresComponentStatusAndPropertyStatus() {
+        PlatformCertificateInformationModel pi = sampleV20Model();
+        pi.setPlatformTraits(samplePlatformTraits());
+        pi.setIsDelta(true);
+
+        TraitMap component = TraitMap.builder()
+                .trait(UTF8StringTrait.builder().traitCategory(TCGObjectIdentifier.tcgTrCatComponentClass).traitValue(new DERUTF8String("c")).build())
+                .trait(UTF8StringTrait.builder().traitCategory(TCGObjectIdentifier.tcgTrCatComponentManufacturer).traitValue(new DERUTF8String("m")).build())
+                .trait(UTF8StringTrait.builder().traitCategory(TCGObjectIdentifier.tcgTrCatComponentModel).traitValue(new DERUTF8String("m")).build())
+                .build(); // Missing Status
+
+        pi.setPlatformConfiguration(PlatformConfigurationV3.builder()
+                .platformComponent(component)
+                .platformProperty(PlatformPropertiesV2.builder()
+                        .propertyName(new DERUTF8String("prop"))
+                        .propertyValue(new DERUTF8String("val"))
+                        .build()) // Missing Status
+                .build());
+
+        List<String> issues = TbsFinalizer.validateAc(CertificateProfile.platformV2_0Ac(), pi);
+        Assertions.assertTrue(issues.contains("Component[0] is missing required trait category: " + TCGObjectIdentifier.tcgTrCatComponentStatus.getId()));
+        Assertions.assertTrue(issues.contains("Property[0] in Delta Platform Certificate SHALL contain the status field."));
+    }
+
+    @Test
+    void validateAc_v20_checksPlatformOwnershipTrait() {
+        PlatformCertificateInformationModel pi = sampleV20Model();
+        pi.setPlatformTraits(samplePlatformTraits());
+
+        TraitMap ownership = TraitMap.builder()
+                .trait(UTF8StringTrait.builder()
+                        .traitCategory(TCGObjectIdentifier.tcgTrCatPlatformManufacturer) // Wrong category
+                        .traitValue(new DERUTF8String("val"))
+                        .build())
+                .build();
+        pi.setPlatformOwnership(ownership);
+
+        List<String> issues = TbsFinalizer.validateAc(CertificateProfile.platformV2_0Ac(), pi);
+        Assertions.assertTrue(issues.contains("PlatformOwnership is missing required trait category: " + TCGObjectIdentifier.tcgTrCatPlatformOwnership.getId()));
+    }
+
+    private PlatformCertificateInformationModel sampleV20Model() {
+        PlatformCertificateInformationModel pi = new PlatformCertificateInformationModel();
+        pi.setIssuer(NameInfo.fromDerB64("MBExDzANBgNVBAMMBlRlc3RDQQ=="));
+        pi.setTcgCredentialSpecification(
+                TCGSpecificationVersion.builder()
+                        .majorVersion(new ASN1Integer(2))
+                        .minorVersion(new ASN1Integer(0))
+                        .revision(new ASN1Integer(43))
+                        .build());
+        pi.setCertSerialNumber(BigInteger.TEN);
+        pi.setNotBefore(new Date());
+        pi.setNotAfter(new Date(System.currentTimeMillis() + 3600000));
+        pi.setHolder(new HolderInfo(null, null));
+        pi.putExtension(TbsEncoderDerivedExtensionsTest.dummyExtension(Extension.authorityKeyIdentifier, "AKI"));
+        pi.putExtension(TbsEncoderDerivedExtensionsTest.dummyExtension(Extension.certificatePolicies, "CP"));
+        pi.putExtension(TbsEncoderDerivedExtensionsTest.dummyExtension(Extension.subjectAlternativeName, "SAN"));
+        return pi;
+    }
+
+    private TraitMap samplePlatformTraits() {
+        return TbsEncoderDerivedExtensionsTest.samplePlatformTraits();
     }
 
     @Test

--- a/src/test/java/paccor/cli/E2ECommandsTest.java
+++ b/src/test/java/paccor/cli/E2ECommandsTest.java
@@ -586,7 +586,7 @@ public class E2ECommandsTest extends TestSupport {
                 "validate",
                 "--x509v2AttrCert", cerBase.toString(),
                 "--publicKeyCert", RES_MLDSA65_CA_CERT,
-                "--components-json", RES_TEST4_COMP_JSON
+                "--components-json", RES_TEST4_COMP_WITH_TRAITS_JSON
         );
         Assertions.assertEquals(0, rcValidateOk, "validate should pass components check");
 

--- a/src/test/java/paccor/cli/E2ECommandsTest.java
+++ b/src/test/java/paccor/cli/E2ECommandsTest.java
@@ -586,7 +586,7 @@ public class E2ECommandsTest extends TestSupport {
                 "validate",
                 "--x509v2AttrCert", cerBase.toString(),
                 "--publicKeyCert", RES_MLDSA65_CA_CERT,
-                "--components-json", RES_TEST4_COMP_WITH_TRAITS_JSON
+                "--components-json", RES_TEST4_COMP_JSON
         );
         Assertions.assertEquals(0, rcValidateOk, "validate should pass components check");
 

--- a/src/test/java/paccor/json/AttributesJsonHelperTest.java
+++ b/src/test/java/paccor/json/AttributesJsonHelperTest.java
@@ -343,8 +343,8 @@ public class AttributesJsonHelperTest {
                         +       "    \"" + Json.ISO9000URI.name() + "\": \"" + iso9000URI + "\""
                         +       "}";
         TBBSecurityAssertions tbsa = ObjectMapperFactory.fromJsonSafe(jsonData, TBBSecurityAssertions.class);
-        Assertions.assertEquals(tbsa.getVersion(), new ASN1Integer(Integer.parseInt(version)));
-        CommonCriteriaMeasures ccInfo = tbsa.getCcInfo();
+        Assertions.assertEquals(new ASN1Integer(Integer.parseInt(version)), tbsa.getVersion().orElse(null));
+        CommonCriteriaMeasures ccInfo = tbsa.getCcInfo().orElseThrow();
         Assertions.assertEquals(ccVersion, ccInfo.getVersion().getString());
         Assertions.assertEquals(EvaluationAssuranceLevel.getInstance(assuranceLevel), ccInfo.getAssuranceLevel());
         Assertions.assertEquals(EvaluationStatus.getInstance(evaluationStatus), ccInfo.getEvaluationStatus());
@@ -352,17 +352,17 @@ public class AttributesJsonHelperTest {
         Assertions.assertEquals(profileOid, ccInfo.getProfileOid().getId());
         Assertions.assertEquals(profileURI, ccInfo.getProfileUri().getUniformResourceIdentifier().getString());
         Assertions.assertEquals(profileAlg, ccInfo.getProfileUri().getHashAlgorithm().getAlgorithm().getId());
-        Assertions.assertArrayEquals(profileHash.getBytes(), Base64.encode(ccInfo.getProfileUri().getHashValue().getBytes()));
+        Assertions.assertArrayEquals(Base64.decode(profileHash), ccInfo.getProfileUri().getHashValue().getOctets());
         Assertions.assertEquals(targetOid, ccInfo.getTargetOid().getId());
         Assertions.assertEquals(targetURI, ccInfo.getTargetUri().getUniformResourceIdentifier().getString());
         Assertions.assertEquals(targetAlg, ccInfo.getTargetUri().getHashAlgorithm().getAlgorithm().getId());
-        Assertions.assertArrayEquals(targetHash.getBytes(), Base64.encode(ccInfo.getTargetUri().getHashValue().getBytes()));
-        FIPSLevel fips = tbsa.getFipsLevel();
+        Assertions.assertArrayEquals(Base64.decode(targetHash), ccInfo.getTargetUri().getHashValue().getOctets());
+        FIPSLevel fips = tbsa.getFipsLevel().orElseThrow();
         Assertions.assertEquals(fipsVersion, fips.getVersion().getString());
         Assertions.assertEquals(SecurityLevel.getInstance(fipsLevel), fips.getLevel());
         Assertions.assertEquals(Boolean.valueOf(fipsPlus), fips.getPlus().isTrue());
-        Assertions.assertEquals(MeasurementRootType.getInstance(rtmType), tbsa.getRtmType());
+        Assertions.assertEquals(MeasurementRootType.getInstance(rtmType), tbsa.getRtmType().orElseThrow());
         Assertions.assertEquals(Boolean.valueOf(iso9000Certified), tbsa.getIso9000Certified().isTrue());
-        Assertions.assertEquals(iso9000URI, tbsa.getIso9000Uri().getString());
+        Assertions.assertEquals(iso9000URI, tbsa.getIso9000Uri().map(s -> s.getString()).orElse(null));
     }
 }

--- a/src/test/java/paccor/json/ComponentAddressDeserializerTest.java
+++ b/src/test/java/paccor/json/ComponentAddressDeserializerTest.java
@@ -1,0 +1,44 @@
+package paccor.json;
+
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+import paccor.tcg.credential.ComponentAddress;
+import tools.jackson.databind.ObjectMapper;
+
+public class ComponentAddressDeserializerTest {
+    @Test
+    public void testDeserializeOneElement() throws Exception {
+        String json = "{\"ethernetMac\": \"00:11:22:33:44:55\"}";
+        ObjectMapper mapper = ObjectMapperFactory.create();
+        ComponentAddress address = mapper.readValue(json, ComponentAddress.class);
+
+        Assertions.assertNotNull(address);
+        Assertions.assertNotNull(address.getAddressType());
+        Assertions.assertNotNull(address.getAddressValue());
+        Assertions.assertEquals("001122334455", address.getAddressValue().getString());
+    }
+
+    @Test
+    public void testDeserializeTwoElements() throws Exception {
+        String json = "{\"addressType\": \"ethernetMac\", \"addressValue\": \"00:11:22:33:44:55\"}";
+        ObjectMapper mapper = ObjectMapperFactory.create();
+        ComponentAddress address = mapper.readValue(json, ComponentAddress.class);
+
+        Assertions.assertNotNull(address);
+        Assertions.assertNotNull(address.getAddressType());
+        Assertions.assertNotNull(address.getAddressValue());
+        Assertions.assertEquals("001122334455", address.getAddressValue().getString());
+    }
+
+    @Test
+    public void testDeserializeEmpty() throws Exception {
+        String json = "{}";
+        ObjectMapper mapper = ObjectMapperFactory.create();
+        // The current implementation of handleOneElement might fail if there are no elements
+        // because it calls iterator().next().
+        // But the main deserialize method filters for size == 1 or 2.
+        // Size 0 will return null (which might throw JacksonIOException due to orElseThrow).
+        
+        Assertions.assertThrows(Exception.class, () -> mapper.readValue(json, ComponentAddress.class));
+    }
+}

--- a/src/test/java/paccor/json/TraitCollectionDeserializerTest.java
+++ b/src/test/java/paccor/json/TraitCollectionDeserializerTest.java
@@ -1,0 +1,87 @@
+package paccor.json;
+
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+import paccor.tcg.credential.StatusTrait;
+import paccor.tcg.credential.TraitCollection;
+import paccor.tcg.credential.UTF8StringTrait;
+import tools.jackson.databind.ObjectMapper;
+
+public class TraitCollectionDeserializerTest {
+    @Test
+    public void testDeserializeArray() throws Exception {
+        String json = """
+            [
+                {
+                    "status": "ATTRIBUTESTATUS_ADDED"
+                },
+                {
+                    "utf8": "Test String Value"
+                }
+            ]
+            """;
+        ObjectMapper mapper = ObjectMapperFactory.create();
+        TraitCollection collection = mapper.readValue(json, TraitCollection.class);
+
+        Assertions.assertNotNull(collection);
+        Assertions.assertEquals(2, collection.size());
+        Assertions.assertTrue(collection.get(0) instanceof StatusTrait);
+        Assertions.assertTrue(collection.get(1) instanceof UTF8StringTrait);
+    }
+
+    @Test
+    public void testDeserializeObject() throws Exception {
+        String json = """
+            {
+                "traits": [
+                    {
+                        "status": "ATTRIBUTESTATUS_ADDED"
+                    }
+                ]
+            }
+            """;
+        ObjectMapper mapper = ObjectMapperFactory.create();
+        TraitCollection collection = mapper.readValue(json, TraitCollection.class);
+
+        Assertions.assertNotNull(collection);
+        Assertions.assertEquals(1, collection.size());
+        Assertions.assertTrue(collection.get(0) instanceof StatusTrait);
+    }
+
+    @Test
+    public void testDeserializeSingleObjectInTraits() throws Exception {
+        String json = """
+            {
+                "traits": {
+                    "status": "ATTRIBUTESTATUS_ADDED"
+                }
+            }
+            """;
+        ObjectMapper mapper = ObjectMapperFactory.create();
+        TraitCollection collection = mapper.readValue(json, TraitCollection.class);
+
+        Assertions.assertNotNull(collection);
+        Assertions.assertEquals(1, collection.size());
+        Assertions.assertTrue(collection.get(0) instanceof StatusTrait);
+    }
+
+    @Test
+    public void testDeserializeEmpty() throws Exception {
+        String json = "[]";
+        ObjectMapper mapper = ObjectMapperFactory.create();
+        TraitCollection collection = mapper.readValue(json, TraitCollection.class);
+
+        Assertions.assertNotNull(collection);
+        Assertions.assertTrue(collection.isEmpty());
+    }
+
+    @Test
+    public void testDeserializeNull() throws Exception {
+        String json = "null";
+        ObjectMapper mapper = ObjectMapperFactory.create();
+        TraitCollection collection = mapper.readValue(json, TraitCollection.class);
+
+        Assertions.assertNotNull(collection);
+        Assertions.assertTrue(collection.isEmpty());
+    }
+}

--- a/src/test/java/paccor/model/PlatformCertificateInformationModelTest.java
+++ b/src/test/java/paccor/model/PlatformCertificateInformationModelTest.java
@@ -10,8 +10,8 @@ import paccor.json.AttributesJsonHelper;
 import paccor.json.HardwareManifestJsonHelper;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
-import paccor.model.CertificateReference;
-import paccor.model.PlatformCertificateInformationModel;
+import paccor.json.TraitMapDeserializerTest;
+import paccor.tcg.credential.TCGObjectIdentifier;
 
 public class PlatformCertificateInformationModelTest {
     private static final String COMP_JSON_WITH_TRAITS = "src/test/resources/tutorials/v2/componentswithtraits.json";
@@ -65,6 +65,36 @@ public class PlatformCertificateInformationModelTest {
         CertificateReference previous = pi.getPreviousPlatformCertificateObjects().getFirst();
         Assertions.assertNotNull(previous.certKind());
         Assertions.assertNotNull(previous.certSpecVersion());
+    }
+
+    @Test
+    public void applyAttributesCarriesOwnershipAndMfgAssertions() throws JsonException {
+        String platformOwnerUtf8 = """
+                {
+                    "traitCategory": "%s",
+                    "utf8": "I got 8 problems but a Trait is all of them."
+                }
+                """.formatted(TCGObjectIdentifier.tcgTrCatPlatformOwnership.getId());
+        String json = """
+                {
+                    "platformOwnership": [
+                        %s,%s,%s
+                    ],
+                    "manufacturingAssertions": [
+                        %s,%s
+                    ]
+                }
+                """.formatted(TraitMapDeserializerTest.boolJson_1, TraitMapDeserializerTest.certificateIdentifierJson_1, platformOwnerUtf8,
+                TraitMapDeserializerTest.entGeoLocationJson_1, TraitMapDeserializerTest.countryOfOriginJson_1);
+
+        AttributesJsonHelper attributes = AttributesJsonHelper.read(json);
+        PlatformCertificateInformationModel pi = new PlatformCertificateInformationModel();
+        pi.applyAttributes(attributes);
+
+        Assertions.assertNotNull(pi.getPlatformOwnership());
+        Assertions.assertNotNull(pi.getManufacturingAssertions());
+        Assertions.assertEquals(3, sizeOf(pi.getPlatformOwnership().flattenTraits()));
+        Assertions.assertEquals(2, sizeOf(pi.getManufacturingAssertions().flattenTraits()));
     }
 
     @Test

--- a/src/test/java/paccor/tcg/credential/ASN1UtilsTest.java
+++ b/src/test/java/paccor/tcg/credential/ASN1UtilsTest.java
@@ -89,7 +89,7 @@ public class ASN1UtilsTest {
         Assertions.assertNotNull(result);
         Assertions.assertEquals(1, result.size());
         Assertions.assertTrue(result.containsKey(2));
-        Assertions.assertEquals(tbb.getRtmType(), result.get(2).getBaseObject());
+        Assertions.assertEquals(tbb.getRtmType().orElse(null), result.get(2).getBaseObject());
     }
 
     @Test

--- a/src/test/java/paccor/tcg/credential/TbbSecurityAssertionsValidationTest.java
+++ b/src/test/java/paccor/tcg/credential/TbbSecurityAssertionsValidationTest.java
@@ -1,16 +1,17 @@
-package paccor.cert;
+package paccor.tcg.credential;
 
-import org.junit.jupiter.api.Assertions;
-import org.junit.jupiter.api.Test;
+import paccor.cert.CertificateProfile;
+import paccor.cert.TbsFinalizer;
 import paccor.model.PlatformCertificateInformationModel;
-import paccor.tcg.credential.*;
 import java.util.List;
 import org.bouncycastle.asn1.ASN1Boolean;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
 
 public class TbbSecurityAssertionsValidationTest {
 
     @Test
-    void validateTbbSecurityAssertions_v20_flagsUnsupportedTraits() {
+    void testFlagsUnsupportedTraits_V2_0() {
         PlatformCertificateInformationModel pi = new PlatformCertificateInformationModel();
         
         // Add an unsupported trait to TBB Security Assertions (BooleanTrait is not allowed)
@@ -36,7 +37,7 @@ public class TbbSecurityAssertionsValidationTest {
     }
 
     @Test
-    void validateTbbSecurityAssertions_v20_acceptsAllowedTraits() {
+    void testAcceptsAllowedTraits_V2_0() {
         PlatformCertificateInformationModel pi = new PlatformCertificateInformationModel();
         
         TraitMap traits = TraitMap.builder()
@@ -58,7 +59,7 @@ public class TbbSecurityAssertionsValidationTest {
     }
     
     @Test
-    void validateTbbSecurityAssertions_v10_doesNotFlagTraits() {
+    void testDoesNotFlagTraits_V1_1() {
         PlatformCertificateInformationModel pi = new PlatformCertificateInformationModel();
         
         // V1.0 doesn't use TraitMap for TBBSecurityAssertions in our validation logic (it uses the legacy structure)
@@ -78,14 +79,35 @@ public class TbbSecurityAssertionsValidationTest {
     @Test
     void testToTraitMapConversion() {
         TBBSecurityAssertions v1 = TBBSecurityAssertions.builder()
+                .ccInfo(CommonCriteriaTraitTest.CC_1_MEASURES)
                 .fipsLevel(FIPSLevel.builder()
                         .version(new org.bouncycastle.asn1.DERIA5String("140-2"))
                         .level(new SecurityLevel(1))
                         .build())
+                .iso9000Uri(ISO9000TraitTest.ISO9000_1.getIso9000Uri())
                 .build();
 
         TraitMap traits = v1.toTraitMap();
         Assertions.assertTrue(traits.containsKey(FIPSLevelTrait.class));
         Assertions.assertEquals(1, traits.get(FIPSLevelTrait.class).size());
+        
+        // Check that filtered trait map works
+        Assertions.assertNotNull(v1.getFipsLevel().orElse(null));
+    }
+
+    @Test
+    void testV20FormatHasNullVersion() throws Exception {
+        TraitMap traits = TraitMap.builder()
+                .trait(RTMTrait.builder().traitValue(new RTMTypes(1)).build())
+                .build();
+        
+        // Encode and decode to ensure we have pure ASN.1 primitives for the heuristic
+        org.bouncycastle.asn1.ASN1Primitive encoded = org.bouncycastle.asn1.ASN1Primitive.fromByteArray(traits.getEncoded());
+        
+        // Parse back as TBBSecurityAssertions
+        TBBSecurityAssertions parsed = TBBSecurityAssertions.getInstance(encoded);
+        
+        Assertions.assertTrue(parsed.getVersion().isEmpty(), "Version should be empty for V2.0 format, but was: " + parsed.getVersion());
+        Assertions.assertTrue(parsed.getTraits().containsKey(RTMTrait.class));
     }
 }


### PR DESCRIPTION
PlatformOwnership and ManufacturingAssertions, both SEQUENCE OF Traits, are added to the Attributes JSON.

EntityGeoLocation and CommonCriteriaEvaluation fields were not being tagged to match the spec.

Attempting to extend my TBBSecurityAssertions class to handle both the legacy/v1.0/v1.1 definition and the v2.0/v2.1 change to become a SEQUENCE OF Traits.

I also added several checks regarding the makeup of Trait sequences to the `paccor certgen ... --finalize` command. 