### PR TITLE
SDA was repeating attributes

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -6,7 +6,7 @@ plugins {
     alias(libs.plugins.ospackage) // see gradle/libs.versions.toml
 }
 
-version = "2.0r6"
+version = "2.0r7"
 
 // Build is split up into multiple files.
 

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -14,6 +14,7 @@ Before you start:
 - Choose a device that possesses a TPM and that you can run commands with elevated privileges.
 - Pick an [Installation](setup/install.md) method for that device.
 - Open a terminal and ensure you can run with elevated privileges.
+- You may be interested to review the [CLI command options](reference/cli-commands.md).
 
 **NOTE:**
 

--- a/docs/reference/cli-commands.md
+++ b/docs/reference/cli-commands.md
@@ -13,7 +13,7 @@ Use this page to view the command options in one place.
 
 ## Global options
 
-These options are accepted by the root command and the subcommands:
+These options are accepted by each command:
 
 | Option | Meaning |
 | --- | --- |
@@ -29,13 +29,22 @@ Builds a JSON envelope that contains:
 
 - the certificate kind and specification version
 - the finalized TBS bytes when enough input is available
-- the signature `AlgorithmIdentifier`
 - a serialized `PlatformCertificateInformationModel`
+- the signature `AlgorithmIdentifier`
+- If you omit `--sig-profile`, paccor tries to infer the algorithm from the issuer certificate and otherwise falls back to an RSA default.
+- Use [Signing Algorithms](signing-algorithms.md) to see the accepted `--sig-profile` values.
 
-Typical usage:
+What you see when you type `paccor certgen -h`:
+
+{%
+include-markdown "./_generated/cli-help/certgen.md"
+%}
+
+Example usage:
 
 ```bash
-bin/paccor certgen \
+paccor certgen \
+  --kind AC
   --issuer-cert TestCA.cert.example.pem \
   --holder-cert TCG_EK_ecc_p384_P-384_Test.pem \
   --attributes-json localhost-policyreference-v2.json \
@@ -46,12 +55,6 @@ bin/paccor certgen \
   --out example-envelope.json
 ```
 
-Notes:
-
-- `certgen` is the command that chooses the signing algorithm OID placed in the envelope.
-- If you omit `--sig-profile`, paccor tries to infer the algorithm from the issuer certificate and otherwise falls back to an RSA default.
-- Use [Signing Algorithms](signing-algorithms.md) when you need the accepted `--sig-profile` values.
-
 ## `paccor assemble`
 
 Consumes an envelope and produces the signed certificate. You must choose exactly one signing mode:
@@ -60,23 +63,27 @@ Consumes an envelope and produces the signed certificate. You must choose exactl
 - PKCS#11 token with `--pkcs11-module`
 - remote signer with `--remote-url`
 - detached signature with `--signature`
+- See [Signing Modes](../tutorials/signing-options.md) for sample usage of PKCS#11, remote, detached, and local key signature modes.
 
-Typical usage:
+- `assemble` will stop if the signature and issuer certificate do not match.
+- If the envelope does not yet contain final TBS data or an algorithm identifier, `assemble` can still write a stub instead of a final credential.
+
+What you see when you type `paccor assemble -h`:
+
+{%
+include-markdown "./_generated/cli-help/assemble.md"
+%}
+
+Example usage:
 
 ```bash
-bin/paccor assemble \
+paccor assemble \
   --in example-envelope.json \
   --out example-cert.pem \
   --pem \
   --local-key TestCA.private.example.pem \
   --issuer-cert TestCA.cert.example.pem
 ```
-
-Notes:
-
-- `assemble` verifies the signature before writing the certificate. If the signature and issuer certificate do not match, the command fails.
-- If the envelope does not yet contain final TBS data or an algorithm identifier, `assemble` can still write a stub instead of a final credential.
-- Use [Signing Modes](../tutorials/signing-options.md) for compact PKCS#11, remote, detached, and local examples.
 
 ## `paccor validate`
 
@@ -86,62 +93,45 @@ Validates a certificate against three buckets of checks:
 - certificate profile/specification checks
 - component matching against expected JSON
 
-Typical usage:
+- Use `--component-matcher RAW` only when you specifically need strict raw comparison rather than normalized matching.
+
+What you see when you type `paccor validate -h`:
+
+{%
+include-markdown "./_generated/cli-help/validate.md"
+%}
+
+Example usage:
 
 ```bash
-bin/paccor validate \
+paccor validate \
   --x509v2AttrCert example-cert.pem \
   --issuer-cert TestCA.cert.example.pem \
   --components-json componentswithtraits.json
 ```
 
-Notes:
-
-- Skipping component or signature validation is intentional and still results in a non-zero exit code.
-- Use `--component-matcher RAW` only when you specifically need strict raw comparison rather than normalized matching.
-
 ## `paccor view`
 
 Prints a compact summary of the certificate contents without validating against external inputs.
 
-Typical usage:
-
-```bash
-bin/paccor view --certificate example-cert.pem
-```
-
 The output includes the certificate kind, certificate type, resolved spec version, holder or subject, issuer, serial, platform specification, platform facts, component count, and counts for previous certificates and cryptographic anchors.
 
-## Generated Help
+What you see when you type `paccor view -h`:
 
-These blocks are generated from the Picocli command definitions so the raw help text stays tied to the code.
+{%
+include-markdown "./_generated/cli-help/view.md"
+%}
+
+Example usage:
+
+```bash
+paccor view --certificate example-cert.pem
+```
 
 ### `paccor`
 
+What you see when you type `paccor -h`:
+
 {%
   include-markdown "./_generated/cli-help/root.md"
-%}
-
-### `paccor certgen`
-
-{%
-  include-markdown "./_generated/cli-help/certgen.md"
-%}
-
-### `paccor assemble`
-
-{%
-  include-markdown "./_generated/cli-help/assemble.md"
-%}
-
-### `paccor validate`
-
-{%
-  include-markdown "./_generated/cli-help/validate.md"
-%}
-
-### `paccor view`
-
-{%
-  include-markdown "./_generated/cli-help/view.md"
 %}

--- a/docs/setup/install.md
+++ b/docs/setup/install.md
@@ -9,6 +9,7 @@ This is the simplest way to get started.
        * `.deb`: Example command: `sudo apt-get install ./paccor_2.0r3_amd64.deb`
        * `.rpm`: Example command: `sudo dnf install ./paccor-2.0r3.x86_64.rpm`
        * `.zip`: Unpack the `.zip` package anywhere you like.
+       * DEB and RPM files are signed. A paccor-public-key.asc file is distributed on the Releases page and can be imported as necessary.
      * __Windows__: Unpack the `.zip` package anywhere you like.
 2. Run the executable with the help command line option.
      * If you installed via a `.deb` or `.rpm` package, the executable is available at `/opt/paccor/bin/paccor -h`.

--- a/src/main/java/paccor/cert/TbsEncoder.java
+++ b/src/main/java/paccor/cert/TbsEncoder.java
@@ -1,6 +1,7 @@
 package paccor.cert;
 
 import java.io.ByteArrayOutputStream;
+import java.io.IOException;
 import java.io.OutputStream;
 import java.lang.reflect.Constructor;
 import java.math.BigInteger;
@@ -212,11 +213,12 @@ public class TbsEncoder {
     private void addAttributes(X509v3CertificateBuilder builder) {
         SubjectDirectoryAttributes attributes = buildSubjectDirectoryAttributes();
         if (attributes != null) {
-            addExtensions((_, _, _) ->
-                    builder.addExtension(
-                            ExtensionContext.subjectDirectoryAttributes.getOid(),
-                            ExtensionContext.subjectDirectoryAttributes.isCritical(),
-                            attributes));
+            try {
+                addExtensions(builder.addExtension(
+                        ExtensionContext.subjectDirectoryAttributes.getOid(),
+                        ExtensionContext.subjectDirectoryAttributes.isCritical(),
+                        attributes));
+            } catch (IOException ignored) {}
         }
     }
 

--- a/src/main/java/paccor/cert/TbsEncoder.java
+++ b/src/main/java/paccor/cert/TbsEncoder.java
@@ -1,7 +1,6 @@
 package paccor.cert;
 
 import java.io.ByteArrayOutputStream;
-import java.io.IOException;
 import java.io.OutputStream;
 import java.lang.reflect.Constructor;
 import java.math.BigInteger;
@@ -218,7 +217,7 @@ public class TbsEncoder {
                         ExtensionContext.subjectDirectoryAttributes.getOid(),
                         ExtensionContext.subjectDirectoryAttributes.isCritical(),
                         attributes));
-            } catch (IOException ignored) {}
+            } catch (Exception ignored) {}
         }
     }
 

--- a/src/test/java/paccor/cli/E2ECommandsTest.java
+++ b/src/test/java/paccor/cli/E2ECommandsTest.java
@@ -1,5 +1,8 @@
 package paccor.cli;
 
+import java.util.Arrays;
+import java.util.Optional;
+import java.util.Vector;
 import org.bouncycastle.asn1.x509.CRLDistPoint;
 import org.bouncycastle.asn1.x509.DistributionPoint;
 import org.bouncycastle.asn1.x509.DistributionPointName;
@@ -21,6 +24,7 @@ import org.bouncycastle.cert.X509AttributeCertificateHolder;
 import org.bouncycastle.cert.X509CertificateHolder;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
+import paccor.model.PlatformCertificateInformationModel;
 import picocli.CommandLine;
 import paccor.tcg.credential.PlatformConfigurationV2;
 import paccor.tcg.credential.PlatformConfigurationV3;
@@ -770,6 +774,23 @@ public class E2ECommandsTest extends TestSupport {
                 "--components-json", RES_GEN1_COMP_JSON_V3
         );
         Assertions.assertEquals(0, rcValidateOk, "validate should pass components check for V3");
+
+        PlatformCertificate certificate = PlatformCertificate.load(cer.toFile());
+        Assertions.assertNotNull(certificate);
+        Assertions.assertTrue(certificate.isPublicKeyCertificate());
+        Extension sdaExt = certificate.getExtension(Extension.subjectDirectoryAttributes);
+        Assertions.assertNotNull(sdaExt);
+        SubjectDirectoryAttributes sda = SubjectDirectoryAttributes.getInstance(sdaExt.getParsedValue());
+        Assertions.assertNotNull(sda);
+        Object[] array = sda.getAttributes().toArray();
+        long size = array.length;
+        long distinct = Arrays.stream(array)
+                .filter(attr -> attr instanceof Attribute)
+                .map(attr -> ((Attribute) attr).getAttrType())
+                .distinct()
+                .count();
+        Assertions.assertEquals(distinct, size, "Duplicate attributes found in subjectDirectoryAttributes");
+
 
         // Negative: tweak a copy of components JSON (change first VALUE string)
         Path badJson = tempDir.resolve("bad-v3.json");

--- a/src/test/java/paccor/cli/E2ECommandsTest.java
+++ b/src/test/java/paccor/cli/E2ECommandsTest.java
@@ -1,8 +1,6 @@
 package paccor.cli;
 
 import java.util.Arrays;
-import java.util.Optional;
-import java.util.Vector;
 import org.bouncycastle.asn1.x509.CRLDistPoint;
 import org.bouncycastle.asn1.x509.DistributionPoint;
 import org.bouncycastle.asn1.x509.DistributionPointName;
@@ -24,7 +22,6 @@ import org.bouncycastle.cert.X509AttributeCertificateHolder;
 import org.bouncycastle.cert.X509CertificateHolder;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
-import paccor.model.PlatformCertificateInformationModel;
 import picocli.CommandLine;
 import paccor.tcg.credential.PlatformConfigurationV2;
 import paccor.tcg.credential.PlatformConfigurationV3;
@@ -785,8 +782,9 @@ public class E2ECommandsTest extends TestSupport {
         Object[] array = sda.getAttributes().toArray();
         long size = array.length;
         long distinct = Arrays.stream(array)
-                .filter(attr -> attr instanceof Attribute)
-                .map(attr -> ((Attribute) attr).getAttrType())
+                .filter(Attribute.class::isInstance)
+                .map(Attribute.class::cast)
+                .map(Attribute::getAttrType)
                 .distinct()
                 .count();
         Assertions.assertEquals(distinct, size, "Duplicate attributes found in subjectDirectoryAttributes");


### PR DESCRIPTION
While generating a PKC platform certificate, subjectDirectoryAttributes was duplicating all attributes for the number of other extensions being entered into the certificate. The correct information was in the certificate but multiple times. Now there should only be one set of attributes within that extension.  

