### PR TITLE
subjectAltName was duplicating the PlatformIdentifier SEQ for 2.0 PKC

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -6,7 +6,7 @@ plugins {
     alias(libs.plugins.ospackage) // see gradle/libs.versions.toml
 }
 
-version = "2.0r7"
+version = "2.0r8"
 
 // Build is split up into multiple files.
 

--- a/src/main/java/paccor/cert/TbsEncoder.java
+++ b/src/main/java/paccor/cert/TbsEncoder.java
@@ -213,10 +213,10 @@ public class TbsEncoder {
         SubjectDirectoryAttributes attributes = buildSubjectDirectoryAttributes();
         if (attributes != null) {
             try {
-                addExtensions(builder.addExtension(
+                builder.addExtension(
                         ExtensionContext.subjectDirectoryAttributes.getOid(),
                         ExtensionContext.subjectDirectoryAttributes.isCritical(),
-                        attributes));
+                        attributes);
             } catch (Exception ignored) {}
         }
     }

--- a/src/test/java/paccor/cert/TbsEncoderDerivedExtensionsTest.java
+++ b/src/test/java/paccor/cert/TbsEncoderDerivedExtensionsTest.java
@@ -107,6 +107,11 @@ public class TbsEncoderDerivedExtensionsTest {
         byte[] tbs = new TbsEncoder(pi, CertificateProfile.platformV2_0Pkc()).buildTbs(SIG_ALG);
 
         Assertions.assertNotNull(tbs);
+        TBSCertificate certificate = TBSCertificate.getInstance(ASN1Primitive.fromByteArray(tbs));
+        GeneralNames encodedNames = GeneralNames.getInstance(
+                certificate.getExtensions().getExtension(Extension.subjectAlternativeName).getParsedValue());
+        Assertions.assertEquals(1, encodedNames.getNames().length,
+                "PKC subjectAltName must contain one PlatformIdentifier sequence");
         GeneralNames names = subjectAlternativeNames(pi);
         Assertions.assertEquals(1, names.getNames().length);
         Assertions.assertEquals(GeneralName.otherName, names.getNames()[0].getTagNo());


### PR DESCRIPTION
subjectAltName was duplicating the PlatformIdentifier SEQ for PKC in certspecversion V2_0